### PR TITLE
Update Filter when Area Type is changed (#5643)

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -13,6 +13,10 @@
 # Plural rules can be found here: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+[PageProblem]
+description = "There is a problem with this page"
+one = "There is a problem with this page"
+
 [Variable]
 description = "Variable"
 one = "Variable"
@@ -46,3 +50,7 @@ one = "Continue"
 [SelectAreaTypeLeadText]
 description = "Select area type"
 one = "Select area type"
+
+[SelectAreaTypeError]
+description = "Select an area type"
+one = "Select an area type"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -13,6 +13,10 @@
 # Plural rules can be found here: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+[PageProblem]
+description = "There is a problem with this page"
+one = "There is a problem with this page"
+
 [Variable]
 description = "Variable"
 one = "Variable"
@@ -46,3 +50,7 @@ one = "Continue"
 [SelectAreaTypeLeadText]
 description = "Select area type"
 one = "Select area type"
+
+[SelectAreaTypeError]
+description = "Select an area type"
+one = "Select an area type"

--- a/assets/templates/partials/error-summary.tmpl
+++ b/assets/templates/partials/error-summary.tmpl
@@ -1,0 +1,14 @@
+<div
+    aria-labelledby="error-summary-title"
+    role="alert"
+    tabindex="-1"
+    autofocus="autofocus"
+    class="ons-panel ons-panel--error ons-u-mt-m"
+>
+    <div class="ons-panel__header">
+        <span id="error-summary-title" data-qa="error-header" class="ons-panel__title ons-u-fs-r--b">{{ localise "PageProblem" .Language 1 }}</span>
+    </div>
+    <div class="ons-panel__body ons-u-fs-r">
+        <a href="#{{.Error.Title}}" class="ons-list__link">{{ localise .Error.Title .Language 1 }}</a>
+    </div>
+</div>

--- a/assets/templates/selector.tmpl
+++ b/assets/templates/selector.tmpl
@@ -2,9 +2,24 @@
 <div class="ons-page__container ons-container">
     <div class="ons-grid ons-u-ml-no">
         {{ template "partials/breadcrumb" . }}
+
+        {{ if .Page.Error.Title }}
+            {{ template "partials/error-summary" .Page }}
+        {{ end}}
+
         <h1 class="ons-u-fs-xxxl ons-u-mt-s">{{ .Page.Metadata.Title }}</h1>
+
         <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
             <div class="ons-page__main ons-u-mt-l">
+                {{ if .Page.Error.Title }}
+                    <div class="ons-panel ons-panel--error ons-panel--no-title" id="{{ .Page.Error.Title }}">
+                        <span class="ons-u-vh">Error: </span>
+                        <div class="ons-panel__body">
+                            <p class="ons-panel__error">
+                                <strong>{{ localise "SelectAreaTypeError" .Language 1 }}</strong>
+                            </p>
+                {{ end }}
+
                 {{ if gt $length 0 }}
                     <form method="post">
                         <fieldset class="ons-fieldset">
@@ -14,11 +29,11 @@
                             <div class="ons-radios__items">
                                 {{ range $i, $selection := .Selections }}
                                     <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
-                                        <span class="ons-radio ons-radio--no-border">
-                                            <input type="radio" id="{{ .Value }}" class="ons-radio__input ons-js-radio" value="{{ .Value }}" name="dimension" {{ if eq $.InitialSelection .Value }}checked{{ end }}>
-                                            <label class="ons-radio__label" for="{{ .Value }}" id="{{ .Value }}-label">{{ .Label }} ({{ .TotalCount }})</label>
-                                        </span>
-                                    </span>
+                                <span class="ons-radio ons-radio--no-border">
+                                    <input type="radio" id="{{ .Value }}" class="ons-radio__input ons-js-radio" value="{{ .Value }}" name="dimension" {{ if eq $.InitialSelection .Value }}checked{{ end }}>
+                                    <label class="ons-radio__label" for="{{ .Value }}" id="{{ .Value }}-label">{{ .Label }} ({{ .TotalCount }})</label>
+                                </span>
+                            </span>
                                     {{ if notLastItem $length $i }}<br>{{ end }}
                                 {{ end }}
                             </div>
@@ -29,6 +44,11 @@
                         </button>
                     </form>
                 {{ end }}
+
+                {{ if .Error.Title}}
+                    </div>
+                {{ end }}
+                </div>
             </div>
         </div>
     </div>

--- a/assets/templates/selector.tmpl
+++ b/assets/templates/selector.tmpl
@@ -6,7 +6,7 @@
         <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
             <div class="ons-page__main ons-u-mt-l">
                 {{ if gt $length 0 }}
-                    <form method="get">
+                    <form method="post">
                         <fieldset class="ons-fieldset">
                             <legend class="ons-fieldset__legend ons-u-mb-s">
                                 {{ localise "SelectAreaTypeLeadText" .Language 1 }}
@@ -15,7 +15,7 @@
                                 {{ range $i, $selection := .Selections }}
                                     <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
                                         <span class="ons-radio ons-radio--no-border">
-                                            <input type="radio" id="{{ .Value }}" class="ons-radio__input ons-js-radio" value="{{ .Value }}" name="area-type" {{ if eq $.InitialSelection .Value }}checked{{ end }}>
+                                            <input type="radio" id="{{ .Value }}" class="ons-radio__input ons-js-radio" value="{{ .Value }}" name="dimension" {{ if eq $.InitialSelection .Value }}checked{{ end }}>
                                             <label class="ons-radio__label" for="{{ .Value }}" id="{{ .Value }}-label">{{ .Label }} ({{ .TotalCount }})</label>
                                         </span>
                                     </span>
@@ -23,6 +23,7 @@
                                 {{ end }}
                             </div>
                         </fieldset>
+                        <input type="hidden" value="{{ .IsAreaType }}" name="is_area_type">
                         <button type="submit" class="ons-btn ons-u-mt-s ons-u-mb-s">
                             <span class="ons-btn__inner">{{ localise "Continue" $.Language 1 }}</span>
                         </button>

--- a/handlers/change_dimension.go
+++ b/handlers/change_dimension.go
@@ -37,6 +37,10 @@ func changeDimension(w http.ResponseWriter, req *http.Request, fc FilterClient, 
 	}
 
 	form, err := parseChangeDimensionForm(req)
+	if isValidationErr(err) {
+		http.Redirect(w, req, fmt.Sprintf("/filters/%s/dimensions/%s?error=true", filterID, dimensionParam), http.StatusMovedPermanently)
+		return
+	}
 	if err != nil {
 		log.Error(ctx, "failed to parse change dimension form", err, logData)
 		setStatusCode(req, w, err)
@@ -54,7 +58,7 @@ func changeDimension(w http.ResponseWriter, req *http.Request, fc FilterClient, 
 		return
 	}
 
-	http.Redirect(w, req, fmt.Sprintf("/filters/%s/dimensions/", filterID), http.StatusMovedPermanently)
+	http.Redirect(w, req, fmt.Sprintf("/filters/%s/dimensions", filterID), http.StatusMovedPermanently)
 }
 
 // changeDimensionForm represents form-data for the ChangeDimension handler.
@@ -67,7 +71,7 @@ type changeDimensionForm struct {
 func parseChangeDimensionForm(req *http.Request) (changeDimensionForm, error) {
 	err := req.ParseForm()
 	if err != nil {
-		return changeDimensionForm{}, fmt.Errorf("erorr parsing form: %w", err)
+		return changeDimensionForm{}, fmt.Errorf("error parsing form: %w", err)
 	}
 
 	dimension := req.FormValue("dimension")
@@ -77,7 +81,7 @@ func parseChangeDimensionForm(req *http.Request) (changeDimensionForm, error) {
 
 	areaType, err := strconv.ParseBool(req.FormValue("is_area_type"))
 	if err != nil {
-		return changeDimensionForm{}, &validationErr{errors.New("missing or invalid value 'is_area_type', expected bool")}
+		return changeDimensionForm{}, &clientErr{errors.New("missing or invalid value 'is_area_type', expected bool")}
 	}
 
 	return changeDimensionForm{

--- a/handlers/change_dimension.go
+++ b/handlers/change_dimension.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	"github.com/ONSdigital/dp-net/v2/handlers"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/gorilla/mux"
+)
+
+// ChangeDimension Handler
+func ChangeDimension(fc FilterClient) http.HandlerFunc {
+	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
+		changeDimension(w, req, fc, accessToken, collectionID)
+	})
+}
+
+func changeDimension(w http.ResponseWriter, req *http.Request, fc FilterClient, accessToken, collectionID string) {
+	ctx := req.Context()
+	vars := mux.Vars(req)
+	filterID := vars["filterID"]
+	dimensionParam := vars["name"]
+
+	logData := log.Data{
+		"filter_id": filterID,
+	}
+
+	dimensionName, err := convertDimensionToName(dimensionParam)
+	if err != nil {
+		log.Error(ctx, "failed to parse dimension name", err, logData)
+		setStatusCode(req, w, err)
+		return
+	}
+
+	form, err := parseChangeDimensionForm(req)
+	if err != nil {
+		log.Error(ctx, "failed to parse change dimension form", err, logData)
+		setStatusCode(req, w, err)
+		return
+	}
+
+	dimension := filter.Dimension{
+		Name:       form.Dimension,
+		IsAreaType: toBoolPtr(form.IsAreaType),
+	}
+
+	if _, _, err = fc.UpdateDimensions(ctx, accessToken, "", collectionID, filterID, dimensionName, "", dimension); err != nil {
+		log.Error(ctx, "error updating filter dimension", err, logData)
+		setStatusCode(req, w, err)
+		return
+	}
+
+	http.Redirect(w, req, fmt.Sprintf("/filters/%s/dimensions/", filterID), http.StatusMovedPermanently)
+}
+
+// changeDimensionForm represents form-data for the ChangeDimension handler.
+type changeDimensionForm struct {
+	Dimension  string
+	IsAreaType bool
+}
+
+// parseChangeDimensionForm parses form data from a http.Request into a changeDimensionForm.
+func parseChangeDimensionForm(req *http.Request) (changeDimensionForm, error) {
+	err := req.ParseForm()
+	if err != nil {
+		return changeDimensionForm{}, fmt.Errorf("erorr parsing form: %w", err)
+	}
+
+	dimension := req.FormValue("dimension")
+	if dimension == "" {
+		return changeDimensionForm{}, &validationErr{errors.New("missing required value 'dimension'")}
+	}
+
+	areaType, err := strconv.ParseBool(req.FormValue("is_area_type"))
+	if err != nil {
+		return changeDimensionForm{}, &validationErr{errors.New("missing or invalid value 'is_area_type', expected bool")}
+	}
+
+	return changeDimensionForm{
+		Dimension:  dimension,
+		IsAreaType: areaType,
+	}, nil
+}

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -31,6 +31,7 @@ type FilterClient interface {
 	GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (f filter.Model, eTag string, err error)
 	GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (dim filter.Dimension, eTag string, err error)
 	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q *filter.QueryParams) (dims filter.Dimensions, eTag string, err error)
+	UpdateDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch string, dimension filter.Dimension) (dim filter.Dimension, eTag string, err error)
 	SubmitFilter(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, ifMatch string, sfr filter.SubmitFilterRequest) (resp *filter.SubmitFilterResponse, eTag string, err error)
 }
 

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -66,7 +67,8 @@ func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClien
 		return
 	}
 
-	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, areaTypes.AreaTypes, dimensionName)
+	isValidationError, _ := strconv.ParseBool(req.URL.Query().Get("error"))
+	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, areaTypes.AreaTypes, dimensionName, isValidationError)
 	rc.BuildPage(w, selector, "selector")
 }
 

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -66,7 +66,7 @@ func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClien
 		return
 	}
 
-	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, areaTypes.AreaTypes, nameParam)
+	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, areaTypes.AreaTypes, dimensionName)
 	rc.BuildPage(w, selector, "selector")
 }
 

--- a/handlers/error.go
+++ b/handlers/error.go
@@ -1,14 +1,28 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 )
 
-// validationErr is a error which occurred while validating client input.
+// validationErr is an error which occurred while validating user input,
+// e.g. field cannot be less than x characters.
 type validationErr struct {
 	error
 }
 
-func (f validationErr) Code() int {
+// isValidationErr checks to see if any error in the chain is a validationErr.
+func isValidationErr(err error) bool {
+	var vErr *validationErr
+	return errors.As(err, &vErr)
+}
+
+// clientErr is an error which occurred while validating client input,
+// e.g. request is missing a hidden form field.
+type clientErr struct {
+	error
+}
+
+func (c clientErr) Code() int {
 	return http.StatusBadRequest
 }

--- a/handlers/error.go
+++ b/handlers/error.go
@@ -1,0 +1,14 @@
+package handlers
+
+import (
+	"net/http"
+)
+
+// validationErr is a error which occurred while validating client input.
+type validationErr struct {
+	error
+}
+
+func (f validationErr) Code() int {
+	return http.StatusBadRequest
+}

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -218,6 +218,22 @@ func (mr *MockFilterClientMockRecorder) SubmitFilter(ctx, userAuthToken, service
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitFilter", reflect.TypeOf((*MockFilterClient)(nil).SubmitFilter), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, ifMatch, sfr)
 }
 
+// UpdateDimensions mocks base method.
+func (m *MockFilterClient) UpdateDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch string, dimension filter.Dimension) (filter.Dimension, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDimensions", ctx, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch, dimension)
+	ret0, _ := ret[0].(filter.Dimension)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UpdateDimensions indicates an expected call of UpdateDimensions.
+func (mr *MockFilterClientMockRecorder) UpdateDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch, dimension interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDimensions", reflect.TypeOf((*MockFilterClient)(nil).UpdateDimensions), ctx, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch, dimension)
+}
+
 // MockDatasetClient is a mock of DatasetClient interface.
 type MockDatasetClient struct {
 	ctrl     *gomock.Controller

--- a/handlers/ptr.go
+++ b/handlers/ptr.go
@@ -1,0 +1,6 @@
+package handlers
+
+// toBoolPtr converts a boolean to a pointer
+func toBoolPtr(val bool) *bool {
+	return &val
+}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -123,9 +123,15 @@ func CreateSelector(req *http.Request, basePage coreModel.Page, dimName, lang st
 }
 
 // CreateAreaTypeSelector maps data to the Overview model
-func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang string, areaType []dimension.AreaType, selectionName string) model.Selector {
+func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang string, areaType []dimension.AreaType, selectionName string, isValidationError bool) model.Selector {
 	p := CreateSelector(req, basePage, selectionName, lang)
 	p.Page.Metadata.Title = "Area Type"
+
+	if isValidationError {
+		p.Page.Error = coreModel.Error{
+			Title: "Error: Select an area type",
+		}
+	}
 
 	var selections []model.Selection
 	for _, area := range areaType {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -130,7 +130,9 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang str
 	var selections []model.Selection
 	for _, area := range areaType {
 		selections = append(selections, model.Selection{
-			Value:      area.ID,
+			// Currently, labels are used instead of ID's, since dimensions are stored/queried using their
+			// display name. Once that changes we can use the area-type ID, knowing it will match the imported dimension.
+			Value:      area.Label,
 			Label:      area.Label,
 			TotalCount: area.TotalCount,
 		})
@@ -138,6 +140,7 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang str
 
 	p.Selections = selections
 	p.InitialSelection = selectionName
+	p.IsAreaType = true
 
 	return p
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -130,7 +130,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		}
 
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", areas, "")
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", areas, "", false)
 
 		expectedSelections := []model.Selection{
 			{Value: "One", Label: "One", TotalCount: 1},
@@ -145,7 +145,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 	Convey("Given a valid page", t, func() {
 		const lang = "en"
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, lang, nil, "")
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, lang, nil, "", false)
 
 		Convey("it sets page metadata", func() {
 			So(changeDimension.BetaBannerEnabled, ShouldBeTrue)
@@ -165,10 +165,19 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 	Convey("Given a selection name", t, func() {
 		const selectionName = "test"
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", nil, selectionName)
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", nil, selectionName, false)
 
 		Convey("it returns the value as an initial selection", func() {
 			So(changeDimension.InitialSelection, ShouldEqual, selectionName)
+		})
+	})
+
+	Convey("Given a validation error", t, func() {
+		req := httptest.NewRequest("", "/", nil)
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", nil, "", true)
+
+		Convey("it returns a populated error", func() {
+			So(changeDimension.Error.Title, ShouldNotBeEmpty)
 		})
 	})
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -133,8 +133,8 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", areas, "")
 
 		expectedSelections := []model.Selection{
-			{Value: "one", Label: "One", TotalCount: 1},
-			{Value: "two", Label: "Two", TotalCount: 2},
+			{Value: "One", Label: "One", TotalCount: 1},
+			{Value: "Two", Label: "Two", TotalCount: 2},
 		}
 
 		Convey("Maps each geography dimension into a selection", func() {
@@ -155,6 +155,10 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 
 		Convey("it sets the title to Area Type", func() {
 			So(changeDimension.Metadata.Title, ShouldEqual, "Area Type")
+		})
+
+		Convey("it sets IsAreaType to true", func() {
+			So(changeDimension.IsAreaType, ShouldBeTrue)
 		})
 	})
 

--- a/model/selector.go
+++ b/model/selector.go
@@ -10,6 +10,7 @@ type Selector struct {
 	Dimensions       Dimension `json:"dimensions"`
 	Selections       []Selection
 	InitialSelection string
+	IsAreaType       bool
 }
 
 // Selection represents a dimension selection (e.g. an Area-type of City)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -33,4 +33,5 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(handlers.FilterFlexOverview(c.Render, c.Filter, c.Dataset))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(handlers.DimensionsSelector(c.Render, c.Filter, c.Dimension))
+	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("POST").HandlerFunc(handlers.ChangeDimension(c.Filter))
 }


### PR DESCRIPTION
### What

https://user-images.githubusercontent.com/3719745/161991533-dbc8dd8a-af6e-4dbb-b3a4-aa144d461c46.mp4

Hooks up the button underneath the area-type radio selection screen so that it updates the dimension in Mongo (via the filter-flex API).

This is dependent on (in order to actually work):
- https://github.com/ONSdigital/dp-cantabular-filter-flex-api/pull/46
- https://github.com/ONSdigital/dp-cantabular-filter-flex-api/pull/54
- https://github.com/ONSdigital/dp-filter-api/pull/236
- https://github.com/ONSdigital/dp-api-clients-go/pull/235

Resolves: [5643](https://trello.com/c/bIwXXHiR)

#### ID/Label mismatch

We still have the [ID/Label mismatch](https://github.com/ONSdigital/dp-frontend-filter-flex-dataset/pull/12#discussion_r835367062) with the  dimensions returned from the Dataset API.

Until this is fixed, I've changed the radio button value to be the label rather than the ID. H

#### Options list on review screen

*Edit: The review screen doesn't display variables anymore since the model update, work is in progress to fix it*

Since the returned dimension doesn't exist on the original dataset, there aren't any options displayed next to it (e.g. `United Kingdom` next to `City`). There is additional work in flight to [add this in](https://trello.com/c/lIsiycMk) by querying the `/areas` endpoint of the Dimensions API.

### Validation

Now includes validation for a legitimate bad request (unselected dimension):

<img width="1057" alt="2022-04-19 at 09 33 03" src="https://user-images.githubusercontent.com/3719745/164202678-fcab7893-f902-4d24-8560-2ea68d925347.png">

### How to review

Confirm the behaviour matches the ticket.

### Who can review

Anyone.
