### PR TITLE
Fix area-type selection screen post filter update (#5659)

### DIFF
--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -28,6 +28,7 @@ type RenderClient interface {
 // FilterClient is an interface with the methods required for a filter client
 type FilterClient interface {
 	GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (f filter.Model, eTag string, err error)
+	GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (dim filter.Dimension, eTag string, err error)
 	UpdateFlexBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID string, m filter.Model, doSubmit bool, populationType string, ifMatch string) (filter.Model, string, error)
 }
 

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -139,6 +139,22 @@ func (m *MockFilterClient) EXPECT() *MockFilterClientMockRecorder {
 	return m.recorder
 }
 
+// GetDimension mocks base method.
+func (m *MockFilterClient) GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (filter.Dimension, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDimension", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
+	ret0, _ := ret[0].(filter.Dimension)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDimension indicates an expected call of GetDimension.
+func (mr *MockFilterClientMockRecorder) GetDimension(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimension", reflect.TypeOf((*MockFilterClient)(nil).GetDimension), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
+}
+
 // GetJobState mocks base method.
 func (m *MockFilterClient) GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (filter.Model, string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### What

A recent change to the [filter model](https://github.com/ONSdigital/dp-cantabular-filter-flex-api/pull/50/files) caused a regression on the area-type selection screen.

This re-instates the previous behaviour using a different method. The dimension is now fetched via the `GetDimension` client method, rather than using the dimensions on the filter job (which are no longer present).

I've caught up with Josh re: the name/label mismatch, and while it's been fixed in one place, it still crops up in others. I'm going to create a separate ticket to cover updating it everywhere so we can stop having issue with the label/name mismatch. 

For now, this assumes a recipe created using the pretty, human-readable label in the `name` field (as did the original PR).

Resolves: 5659 (https://trello.com/c/5jX64Vhm)

### How to review

Double check the changes make sense.

### Who can review

Anyone.
