### PR TITLE
Use dimension ID/Name instead of label (#5664)

### DIFF
--- a/assets/templates/partials/summary.tmpl
+++ b/assets/templates/partials/summary.tmpl
@@ -14,7 +14,7 @@
                 </thead>
                 {{ range $i, $dim := .Dimensions }}
                     <tbody class="ons-summary__item">
-                        <tr id="{{.EncodedName}}" class="ons-summary__row ons-summary__row--has-values ons-grid--flex@xxs@s ons-grid--between@xxs@s{{ if eq $i 0 }} ons-u-bt{{ end }}{{ if last $i $.Dimensions }} ons-u-bb{{ end }}">
+                        <tr id="{{.ID}}" class="ons-summary__row ons-summary__row--has-values ons-grid--flex@xxs@s ons-grid--between@xxs@s{{ if eq $i 0 }} ons-u-bt{{ end }}{{ if last $i $.Dimensions }} ons-u-bb{{ end }}">
                             <td class="ons-summary__item-title ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-order--1 ons-u-bb-no@xxs@s ons-u-flex--2@xxs@s">
                                 <div class="ons-summary__item--text ons-u-fw-b">{{ .Name }}</div>
                             </td>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-flex-dataset
 go 1.17
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.117.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.121.0
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.114.2 h1:3OhSxWwddz+j5NKkDMPRUGpkL
 github.com/ONSdigital/dp-api-clients-go/v2 v2.114.2/go.mod h1:/Pa0nFxsXQVkMz8ywCfx0dIa6OPbHRup7JRHsb6gBCU=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.117.0 h1:F8VFk7f/cToCOfm3md6ZNMzNb1ddfoc94+24td0AjIE=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.117.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.121.0 h1:E1WzfE6wHFJc78uahGaXvu7Hhd/LTtvCKv3rwR9QiJY=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.121.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-cookies v0.3.3 h1:KXX4swf+OnljIYbsTYICIBjuRJoxQukGWKBTvBaISlA=
 github.com/ONSdigital/dp-cookies v0.3.3/go.mod h1:qyvkAXoVLMNU9Xf1U5zFGRnuWyLxQ/mHloXUXyzcgb8=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/handlers/change_dimension.go
+++ b/handlers/change_dimension.go
@@ -23,22 +23,15 @@ func changeDimension(w http.ResponseWriter, req *http.Request, fc FilterClient, 
 	ctx := req.Context()
 	vars := mux.Vars(req)
 	filterID := vars["filterID"]
-	dimensionParam := vars["name"]
+	dimensionName := vars["name"]
 
 	logData := log.Data{
 		"filter_id": filterID,
 	}
 
-	dimensionName, err := convertDimensionToName(dimensionParam)
-	if err != nil {
-		log.Error(ctx, "failed to parse dimension name", err, logData)
-		setStatusCode(req, w, err)
-		return
-	}
-
 	form, err := parseChangeDimensionForm(req)
 	if isValidationErr(err) {
-		http.Redirect(w, req, fmt.Sprintf("/filters/%s/dimensions/%s?error=true", filterID, dimensionParam), http.StatusMovedPermanently)
+		http.Redirect(w, req, fmt.Sprintf("/filters/%s/dimensions/%s?error=true", filterID, dimensionName), http.StatusMovedPermanently)
 		return
 	}
 	if err != nil {
@@ -48,7 +41,8 @@ func changeDimension(w http.ResponseWriter, req *http.Request, fc FilterClient, 
 	}
 
 	dimension := filter.Dimension{
-		Name:       form.Dimension,
+		Name:       dimensionName,
+		ID:         form.Dimension,
 		IsAreaType: toBoolPtr(form.IsAreaType),
 	}
 

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -2,10 +2,7 @@ package handlers
 
 import (
 	"net/http"
-	"net/url"
 	"strconv"
-	"strings"
-	"unicode"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mapper"
@@ -25,7 +22,7 @@ func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClien
 	ctx := req.Context()
 	vars := mux.Vars(req)
 	filterID := vars["filterID"]
-	nameParam := vars["name"]
+	dimensionName := vars["name"]
 
 	logData := log.Data{
 		"filter_id": filterID,
@@ -34,13 +31,6 @@ func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClien
 	currentFilter, _, err := fc.GetJobState(ctx, accessToken, "", "", collectionID, filterID)
 	if err != nil {
 		log.Error(ctx, "failed to get job state", err, logData)
-		setStatusCode(req, w, err)
-		return
-	}
-
-	dimensionName, err := convertDimensionToName(nameParam)
-	if err != nil {
-		log.Error(ctx, "failed to parse dimension name", err, logData)
 		setStatusCode(req, w, err)
 		return
 	}
@@ -68,7 +58,7 @@ func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClien
 	}
 
 	isValidationError, _ := strconv.ParseBool(req.URL.Query().Get("error"))
-	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, areaTypes.AreaTypes, dimensionName, isValidationError)
+	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, areaTypes.AreaTypes, filterDimension, isValidationError)
 	rc.BuildPage(w, selector, "selector")
 }
 
@@ -79,20 +69,4 @@ func isAreaType(dimension filter.Dimension) bool {
 	}
 
 	return *dimension.IsAreaType
-}
-
-// convertDimensionToName takes a URL-coded param for a dimension name and attempts to convert it to the
-// pretty label. This is temporary/best-effort, and only a stopgap until we start using ID's/names everywhere.
-// Changing everything to use these will involve updating several services, including the importer, so to
-// restore the journey right now we're taking the hacky approach.
-// Example: `number+of+siblings+%283+mappings%29` -> `Number of siblings (3 mappings)`
-func convertDimensionToName(param string) (string, error) {
-	selection, err := url.QueryUnescape(param)
-	if err != nil {
-		return "", err
-	}
-
-	// Sentence case the param
-	runes := []rune(strings.ToLower(selection))
-	return string(append([]rune{unicode.ToUpper(runes[0])}, runes[1:]...)), nil
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -292,8 +292,7 @@ func TestUnitHandlers(t *testing.T) {
 				})
 			})
 
-			// This can be removed once we start using the name/ID.
-			Convey("Then the dimensions API should be queried using the display name", func() {
+			Convey("Then the dimensions API should be queried using the dimension name", func() {
 				mockFilter := NewMockFilterClient(mockCtrl)
 				mockFilter.
 					EXPECT().
@@ -302,7 +301,7 @@ func TestUnitHandlers(t *testing.T) {
 					AnyTimes()
 				mockFilter.
 					EXPECT().
-					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), "Siblings").
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), "siblings").
 					Return(stubDimension, "", nil).
 					AnyTimes()
 
@@ -354,9 +353,8 @@ func TestUnitHandlers(t *testing.T) {
 			}
 
 			Convey("When area types are returned", func() {
-				// Currently, labels are used instead of ID's, since dimensions are stored/queried using their
-				// display name. Once that changes we can use the area-type ID, knowing it will match the imported dimension.
 				Convey("Then the page should contain a list of area type selections", func() {
+					const dimensionID = "city"
 					const dimensionLabel = "City"
 
 					mockFilter := NewMockFilterClient(mockCtrl)
@@ -376,7 +374,7 @@ func TestUnitHandlers(t *testing.T) {
 						Return(
 							dimension.GetAreaTypesResponse{
 								AreaTypes: []dimension.AreaType{{
-									ID:         dimensionLabel,
+									ID:         dimensionID,
 									Label:      dimensionLabel,
 									TotalCount: 1,
 								}},
@@ -398,7 +396,7 @@ func TestUnitHandlers(t *testing.T) {
 							pageMatchesSelections{
 								selections: []model.Selection{
 									{
-										Value:      dimensionLabel,
+										Value:      dimensionID,
 										Label:      dimensionLabel,
 										TotalCount: 1,
 									},
@@ -593,25 +591,26 @@ func TestUnitHandlers(t *testing.T) {
 
 			Convey("When the filter client's `UpdateDimensions` method is called, it is passed the new dimension", func() {
 				const filterID = "1234"
-				const currentDimension = "City"
-				const newDimension = "Country"
+				const dimensionName = "geography"
+				const newDimension = "country"
 
 				expDimension := filter.Dimension{
-					Name:       newDimension,
+					Name:       "geography",
+					ID:         newDimension,
 					IsAreaType: toBoolPtr(true),
 				}
 
 				filterClient := NewMockFilterClient(mockCtrl)
 				filterClient.
 					EXPECT().
-					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), filterID, currentDimension, gomock.Any(), gomock.Eq(expDimension)).
+					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), filterID, dimensionName, gomock.Any(), gomock.Eq(expDimension)).
 					Return(filter.Dimension{}, "", nil)
 
 				formData := url.Values{}
 				formData.Add("dimension", newDimension)
 				formData.Add("is_area_type", "true")
 
-				runChangeDimension(filterID, currentDimension, formData, ChangeDimension(filterClient))
+				runChangeDimension(filterID, dimensionName, formData, ChangeDimension(filterClient))
 			})
 
 			Convey("When the filter API client responds with an error", func() {

--- a/model/dimesion.go
+++ b/model/dimesion.go
@@ -7,7 +7,7 @@ type Dimension struct {
 	TruncateLink string   `json:"truncate_link"`
 	OptionsCount int      `json:"options_count"`
 	Name         string   `json:"name"`
-	EncodedName  string   `json:"encoded_name"`
+	ID           string   `json:"id"`
 	URI          string   `json:"uri"`
 	IsAreaType   bool     `json:"is_area_type"`
 }


### PR DESCRIPTION
### What

https://user-images.githubusercontent.com/3719745/165282234-2a11d1a7-365c-431f-9b8d-5c73c2eee31b.mp4

Updates the change dimension submission and selection page to use the machine readable labels/ID's introduced as part of [5664](https://trello.com/c/3TbBPTvY). The dimension name is now consistent (e.g. `geography`, while the ID is updated as part of the `PUT` request.

### How to review

Sense check.

### Who can review

Anyone, but probably Team B.
