### PR TITLE
Use areas endpoint to populate dimension review table (#5665)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-flex-dataset
 go 1.17
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.121.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.124.0
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net/v2 v2.3.0

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -42,5 +42,6 @@ type DatasetClient interface {
 
 // DimensionClient is an interface with methods required for a dimension client
 type DimensionClient interface {
+	GetAreas(ctx context.Context, input dimension.GetAreasInput) (dimension.GetAreasResponse, error)
 	GetAreaTypes(ctx context.Context, userAuthToken, serviceAuthToken, datasetID string) (dimension.GetAreaTypesResponse, error)
 }

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -309,3 +309,18 @@ func (mr *MockDimensionClientMockRecorder) GetAreaTypes(ctx, userAuthToken, serv
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAreaTypes", reflect.TypeOf((*MockDimensionClient)(nil).GetAreaTypes), ctx, userAuthToken, serviceAuthToken, datasetID)
 }
+
+// GetAreas mocks base method.
+func (m *MockDimensionClient) GetAreas(ctx context.Context, input dimension.GetAreasInput) (dimension.GetAreasResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAreas", ctx, input)
+	ret0, _ := ret[0].(dimension.GetAreasResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAreas indicates an expected call of GetAreas.
+func (mr *MockDimensionClientMockRecorder) GetAreas(ctx, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAreas", reflect.TypeOf((*MockDimensionClient)(nil).GetAreas), ctx, input)
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -31,7 +31,7 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 
 	r.StrictSlash(true).Path("/filters/{filterID}/submit").Methods("POST").HandlerFunc(handlers.Submit(c.Filter))
 
-	r.StrictSlash(true).Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(handlers.FilterFlexOverview(c.Render, c.Filter, c.Dataset))
+	r.StrictSlash(true).Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(handlers.FilterFlexOverview(c.Render, c.Filter, c.Dataset, c.Dimension))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(handlers.DimensionsSelector(c.Render, c.Filter, c.Dimension))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("POST").HandlerFunc(handlers.ChangeDimension(c.Filter))
 }


### PR DESCRIPTION
### What

https://user-images.githubusercontent.com/3719745/165785616-954e58b5-6475-420a-b8f8-a41e49eea752.mp4

If a dimension is an area type, we use the Dimensions API /areas endpoint to return a list of areas for the given dataset. We can't reliably use the dimension options stored against the dimension, as the user may have changed it to one which hasn't been imported.

Resolves: [5665](https://trello.com/c/oJqRypat)

### How to review

Sense check.

### Who can review

Anyone, but probably Team B.
