### PR TITLE
Feature/5683 populate collapsible on filter summary

### DIFF
--- a/assets/templates/partials/summary.tmpl
+++ b/assets/templates/partials/summary.tmpl
@@ -18,14 +18,16 @@
                             <td class="ons-summary__item-title ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-order--1 ons-u-bb-no@xxs@s ons-u-flex--2@xxs@s">
                                 <div class="ons-summary__item--text ons-u-fw-b">{{ .Name }}</div>
                             </td>
-                            <td class="ons-summary__values ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-pl-no@xxs@s ons-u-order--3 ons-u-fw@xxs@s ons-u-pt-no@xxs@s ons-u-bb-no@xxs@s ons-u-d-b@xxs@s">
+                            <td class="ons-summary__values ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-pl-no@xxs@s ons-u-order--3 ons-u-fw@xxs@s
+                                    ons-u-pt-no@xxs@s ons-u-bb-no@xxs@s ons-u-d-b@xxs@s">
                                 {{ $length := len .Options }}
                                 {{ $strOptCount := intToString .OptionsCount }}
                                 {{ $isTruncated := .IsTruncated }}
                                 {{ if eq .IsAreaType false }}
                                     {{ localise "HasSelectedCategories" $lang 1 $strOptCount }}
                                     <div class="ons-u-mt-s ons-u-fs-s ons-list--container">
-                                        <ul class="ons-list{{ if $isTruncated }}--truncated{{end}}{{ if or (gt $length 9) ($isTruncated) }} ons-u-mb-xs{{else}} ons-u-m-no{{end}}">
+                                        <ul class="ons-list{{ if $isTruncated }}--truncated{{end}}{{ if or (gt $length 9) ($isTruncated) }} ons-u-mb-xs{{else}}
+                                                ons-u-m-no{{end}}">
                                             {{ range $i, $opt := .Options }}
                                                 <li class="ons-list__item{{ if $isTruncated }}--truncated{{end}}">
                                                     {{ . }}
@@ -66,7 +68,9 @@
                     </tbody>
                 {{ end }}
             </table>
-            {{ template "partials/collapsible" . }}
+            {{ if .Collapsible.CollapsibleItems }}
+                {{ template "partials/collapsible" . }}
+            {{ end }}
         </div>
     </div>
 </section>

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/9b88fcc"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/778ac19"
 	}
 
 	return cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
 				So(cfg.BindAddr, ShouldEqual, "localhost:20100")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/9b88fcc")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/778ac19")
 				So(cfg.SupportedLanguages, ShouldResemble, []string{"en", "cy"})
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-flex-dataset
 go 1.17
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.137.0
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net/v2 v2.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/ONSdigital/dp-frontend-filter-flex-dataset
 go 1.17
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.124.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net/v2 v2.3.0
-	github.com/ONSdigital/dp-renderer v1.20.1
+	github.com/ONSdigital/dp-renderer v1.28.0
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,10 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.117.0 h1:F8VFk7f/cToCOfm3md6ZNMzNb
 github.com/ONSdigital/dp-api-clients-go/v2 v2.117.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.121.0 h1:E1WzfE6wHFJc78uahGaXvu7Hhd/LTtvCKv3rwR9QiJY=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.121.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.124.0 h1:ZLfk00gODZ/iZ0lRld3J4bo781s5EhHX0rIIerEfu5M=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.124.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0 h1:QMv0QvdvMt0x6CTua8T8DDgcfP+GoJ1VuLBLoXyMiKE=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-cookies v0.3.3 h1:KXX4swf+OnljIYbsTYICIBjuRJoxQukGWKBTvBaISlA=
 github.com/ONSdigital/dp-cookies v0.3.3/go.mod h1:qyvkAXoVLMNU9Xf1U5zFGRnuWyLxQ/mHloXUXyzcgb8=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -78,6 +82,8 @@ github.com/ONSdigital/dp-net/v2 v2.3.0 h1:Qm4OmtLRS5RDVk/1uC6NvKJVsTJL+nLUWWjl4S
 github.com/ONSdigital/dp-net/v2 v2.3.0/go.mod h1:8X7E1wiJxL59qaDFt3ShDfFLfIGs4WMRPx1sZIgAqbU=
 github.com/ONSdigital/dp-renderer v1.20.1 h1:7iz25P+Dc01O5QSr6jkMpmamU5wdUBnpGzujpRGdNZE=
 github.com/ONSdigital/dp-renderer v1.20.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.28.0 h1:BInquwPyselv6PnkOWWwAqbabqm0XJWbPlhMwzP+wCs=
+github.com/ONSdigital/dp-renderer v1.28.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.124.0 h1:ZLfk00gODZ/iZ0lRld3J4bo78
 github.com/ONSdigital/dp-api-clients-go/v2 v2.124.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0 h1:QMv0QvdvMt0x6CTua8T8DDgcfP+GoJ1VuLBLoXyMiKE=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.137.0 h1:lFeUQf/Kiq2wUNyx3Ln9aEmKboyiDB9yyQ0Vrbr9k50=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.137.0/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-cookies v0.3.3 h1:KXX4swf+OnljIYbsTYICIBjuRJoxQukGWKBTvBaISlA=
 github.com/ONSdigital/dp-cookies v0.3.3/go.mod h1:qyvkAXoVLMNU9Xf1U5zFGRnuWyLxQ/mHloXUXyzcgb8=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/handlers/change_dimension_test.go
+++ b/handlers/change_dimension_test.go
@@ -1,0 +1,152 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestChangeDimensionHandler(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	Convey("Change dimension", t, func() {
+		stubFormData := url.Values{}
+		stubFormData.Add("dimension", "country")
+		stubFormData.Add("is_area_type", "true")
+
+		Convey("Given a valid dimension", func() {
+			Convey("When the user is redirected to the dimensions review screen", func() {
+				const filterID = "1234"
+
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Dimension{}, "", nil).
+					AnyTimes()
+
+				w := runChangeDimension(filterID, "city", stubFormData, ChangeDimension(filterClient))
+
+				Convey("Then the location header should match the review screen", func() {
+					So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/filters/%s/dimensions", filterID))
+				})
+
+				Convey("And the status code should be 301", func() {
+					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
+				})
+			})
+
+			Convey("When the filter client's `UpdateDimensions` method is called, it is passed the new dimension", func() {
+				const filterID = "1234"
+				const dimensionName = "geography"
+				const newDimension = "country"
+
+				expDimension := filter.Dimension{
+					Name:       "geography",
+					ID:         newDimension,
+					IsAreaType: toBoolPtr(true),
+				}
+
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), filterID, dimensionName, gomock.Any(), gomock.Eq(expDimension)).
+					Return(filter.Dimension{}, "", nil)
+
+				formData := url.Values{}
+				formData.Add("dimension", newDimension)
+				formData.Add("is_area_type", "true")
+
+				runChangeDimension(filterID, dimensionName, formData, ChangeDimension(filterClient))
+			})
+
+			Convey("When the filter API client responds with an error", func() {
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Dimension{}, "", errors.New("internal error"))
+
+				w := runChangeDimension("test", "test", stubFormData, ChangeDimension(filterClient))
+
+				Convey("Then the client should not be redirected", func() {
+					So(w.Header().Get("Location"), ShouldBeEmpty)
+				})
+
+				Convey("And the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+		})
+
+		Convey("Given an invalid request", func() {
+			Convey("When the area type has not been provided", func() {
+				formData := url.Values{}
+				formData.Add("is_area_type", "true")
+
+				w := runChangeDimension("test", "test", formData, ChangeDimension(NewMockFilterClient(mockCtrl)))
+
+				Convey("Then the client should be redirected with the error query param", func() {
+					location := w.Header().Get("Location")
+					So(location, ShouldNotBeEmpty)
+
+					parse, err := url.Parse(location)
+					So(err, ShouldBeNil)
+
+					query := parse.Query()
+					So(query["error"], ShouldNotBeEmpty)
+				})
+
+				Convey("And the status code should be 301", func() {
+					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
+				})
+			})
+
+			Convey("When the request is missing the hidden required form values", func() {
+				tests := map[string]url.Values{
+					"Missing is_area_type":       {"dimension": []string{"country"}},
+					"Invalid is_area_type value": {"dimension": []string{"country"}, "is_area_type": []string{"no"}},
+				}
+
+				for name, formData := range tests {
+					Convey(name, func() {
+						w := runChangeDimension("test", "test", formData, ChangeDimension(NewMockFilterClient(mockCtrl)))
+
+						Convey("Then the client should not be redirected", func() {
+							So(w.Header().Get("Location"), ShouldBeEmpty)
+						})
+
+						Convey("And the status code should be 400", func() {
+							So(w.Code, ShouldEqual, http.StatusBadRequest)
+						})
+					})
+				}
+			})
+		})
+	})
+}
+
+func runChangeDimension(filterID, dimension string, formData url.Values, handler http.HandlerFunc) *httptest.ResponseRecorder {
+	encodedFormData := formData.Encode()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/filters/%s/dimensions/%s", filterID, dimension), strings.NewReader(encodedFormData))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Content-Length", strconv.Itoa(len(encodedFormData)))
+
+	w := httptest.NewRecorder()
+
+	router := mux.NewRouter()
+	router.HandleFunc("/filters/{filterID}/dimensions/{name}", handler)
+	router.ServeHTTP(w, req)
+
+	return w
+}

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -38,6 +38,7 @@ type FilterClient interface {
 // DatasetClient is an interface with methods required for a dataset client
 type DatasetClient interface {
 	GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, q *dataset.QueryParams) (m dataset.Options, err error)
+	GetVersionDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m dataset.VersionDimensions, err error)
 }
 
 // DimensionClient is an interface with methods required for a dimension client

--- a/handlers/dimensions_test.go
+++ b/handlers/dimensions_test.go
@@ -1,0 +1,524 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/dimension"
+	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/model"
+	coreModel "github.com/ONSdigital/dp-renderer/model"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDimensionsHandler(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	cfg := initialiseMockConfig()
+
+	Convey("Dimensions Selector", t, func() {
+		Convey("Given a valid dimension param for a filter", func() {
+			Convey("Then the page title contains the dimension name", func() {
+				const dimensionName = "Number Of Siblings"
+
+				mockFilter := NewMockFilterClient(mockCtrl)
+				mockFilter.
+					EXPECT().
+					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Model{}, "", nil)
+				mockFilter.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Dimension{Name: dimensionName}, "", nil).
+					AnyTimes()
+
+				mockRend := NewMockRenderClient(mockCtrl)
+				mockRend.
+					EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+					AnyTimes()
+
+				mockRend.
+					EXPECT().
+					BuildPage(gomock.Any(), pageHasTitle{dimensionName}, gomock.Any())
+
+				w := runDimensionsSelector(
+					"number+of+siblings",
+					DimensionsSelector(mockRend, mockFilter, NewMockDimensionClient(mockCtrl)),
+				)
+
+				Convey("And the status code should be 200", func() {
+					So(w.Code, ShouldEqual, http.StatusOK)
+				})
+			})
+		})
+
+		Convey("Given a dimension param which is missing from a filter", func() {
+			mockFilter := NewMockFilterClient(mockCtrl)
+			mockFilter.
+				EXPECT().
+				GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(filter.Model{}, "", nil) // No filter dimensions
+			mockFilter.
+				EXPECT().
+				GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(filter.Dimension{}, "", &filter.ErrInvalidFilterAPIResponse{ExpectedCode: http.StatusOK, ActualCode: http.StatusNotFound}).
+				AnyTimes()
+
+			w := runDimensionsSelector(
+				"city",
+				DimensionsSelector(NewMockRenderClient(mockCtrl), mockFilter, NewMockDimensionClient(mockCtrl)),
+			)
+
+			Convey("Then the status code should be 404", func() {
+				So(w.Code, ShouldEqual, http.StatusNotFound)
+			})
+		})
+
+		Convey("Given a dimension param which is not an area type", func() {
+			const dimensionName = "siblings"
+
+			stubDimension := filter.Dimension{
+				Name:       dimensionName,
+				IsAreaType: toBoolPtr(false),
+			}
+
+			// This will change, but represents the current non-area-type behaviour.
+			Convey("Then the page should contain no selections", func() {
+				mockFilter := NewMockFilterClient(mockCtrl)
+				mockFilter.
+					EXPECT().
+					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Model{}, "", nil).
+					AnyTimes()
+				mockFilter.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(stubDimension, "", nil).
+					AnyTimes()
+
+				mockRend := NewMockRenderClient(mockCtrl)
+				mockRend.
+					EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+					AnyTimes()
+
+				mockRend.
+					EXPECT().
+					// Assert that there are no selections passed to BuildPage
+					BuildPage(gomock.Any(), pageMatchesSelections{}, gomock.Any())
+
+				w := runDimensionsSelector(
+					dimensionName,
+					DimensionsSelector(mockRend, mockFilter, NewMockDimensionClient(mockCtrl)),
+				)
+
+				Convey("And the status code should be 200", func() {
+					So(w.Code, ShouldEqual, http.StatusOK)
+				})
+			})
+
+			Convey("Then the page should have the area type bool set to false", func() {
+				mockFilter := NewMockFilterClient(mockCtrl)
+				mockFilter.
+					EXPECT().
+					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Model{}, "", nil).
+					AnyTimes()
+				mockFilter.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(stubDimension, "", nil).
+					AnyTimes()
+
+				mockRend := NewMockRenderClient(mockCtrl)
+				mockRend.
+					EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+					AnyTimes()
+
+				mockRend.
+					EXPECT().
+					// Assert that the area type boolean is false
+					BuildPage(gomock.Any(), pageIsAreaType{false}, gomock.Any())
+
+				w := runDimensionsSelector(
+					dimensionName,
+					DimensionsSelector(mockRend, mockFilter, NewMockDimensionClient(mockCtrl)),
+				)
+
+				Convey("And the status code should be 200", func() {
+					So(w.Code, ShouldEqual, http.StatusOK)
+				})
+			})
+
+			Convey("Then the dimensions API should be queried using the dimension name", func() {
+				mockFilter := NewMockFilterClient(mockCtrl)
+				mockFilter.
+					EXPECT().
+					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Model{}, "", nil).
+					AnyTimes()
+				mockFilter.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), "siblings").
+					Return(stubDimension, "", nil).
+					AnyTimes()
+
+				mockRend := NewMockRenderClient(mockCtrl)
+				mockRend.
+					EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+					AnyTimes()
+
+				mockRend.
+					EXPECT().
+					BuildPage(gomock.Any(), gomock.Any(), gomock.Any())
+
+				w := runDimensionsSelector(
+					dimensionName,
+					DimensionsSelector(mockRend, mockFilter, NewMockDimensionClient(mockCtrl)),
+				)
+
+				Convey("And the status code should be 200", func() {
+					So(w.Code, ShouldEqual, http.StatusOK)
+				})
+			})
+
+			Convey("When the filter API responds with an error", func() {
+				mockFilter := NewMockFilterClient(mockCtrl)
+				mockFilter.EXPECT().
+					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Model{}, "", errors.New("oh no")).
+					AnyTimes()
+
+				w := runDimensionsSelector(
+					dimensionName,
+					DimensionsSelector(NewMockRenderClient(mockCtrl), mockFilter, NewMockDimensionClient(mockCtrl)),
+				)
+
+				Convey("Then the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+		})
+
+		Convey("Given an area type", func() {
+			const dimensionName = "city"
+
+			stubAreaTypeDimension := filter.Dimension{
+				Name:       dimensionName,
+				IsAreaType: toBoolPtr(true),
+			}
+
+			Convey("When area types are returned", func() {
+				Convey("Then the page should contain a list of area type selections", func() {
+					const dimensionID = "city"
+					const dimensionLabel = "City"
+
+					mockFilter := NewMockFilterClient(mockCtrl)
+					mockFilter.EXPECT().
+						GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.Model{}, "", nil).
+						AnyTimes()
+					mockFilter.
+						EXPECT().
+						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(stubAreaTypeDimension, "", nil).
+						AnyTimes()
+
+					mockDimension := NewMockDimensionClient(mockCtrl)
+					mockDimension.EXPECT().
+						GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(
+							dimension.GetAreaTypesResponse{
+								AreaTypes: []dimension.AreaType{{
+									ID:         dimensionID,
+									Label:      dimensionLabel,
+									TotalCount: 1,
+								}},
+							},
+							nil,
+						).
+						AnyTimes()
+
+					mockRend := NewMockRenderClient(mockCtrl)
+					mockRend.EXPECT().
+						NewBasePageModel().
+						Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+						AnyTimes()
+
+					// Validate page data contains selections
+					mockRend.EXPECT().
+						BuildPage(
+							gomock.Any(),
+							pageMatchesSelections{
+								selections: []model.Selection{
+									{
+										Value:      dimensionID,
+										Label:      dimensionLabel,
+										TotalCount: 1,
+									},
+								},
+							},
+							"selector",
+						)
+
+					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockDimension))
+
+					Convey("And the status code should be 200", func() {
+						So(w.Code, ShouldEqual, http.StatusOK)
+					})
+				})
+
+				Convey("Then the dimensions API client should request area types using the cantabular ID", func() {
+					const cantabularID = "cantabular"
+
+					mockFilter := NewMockFilterClient(mockCtrl)
+					mockFilter.EXPECT().
+						GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.Model{PopulationType: cantabularID}, "", nil).
+						AnyTimes()
+					mockFilter.
+						EXPECT().
+						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(stubAreaTypeDimension, "", nil).
+						AnyTimes()
+
+					mockDimension := NewMockDimensionClient(mockCtrl)
+					mockDimension.EXPECT().
+						GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), cantabularID).
+						Return(dimension.GetAreaTypesResponse{}, nil)
+
+					mockRend := NewMockRenderClient(mockCtrl)
+					mockRend.EXPECT().
+						NewBasePageModel().
+						Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+						AnyTimes()
+
+					mockRend.
+						EXPECT().
+						BuildPage(gomock.Any(), gomock.Any(), "selector").
+						AnyTimes()
+
+					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockDimension))
+
+					Convey("And the status code should be 200", func() {
+						So(w.Code, ShouldEqual, http.StatusOK)
+					})
+				})
+
+				Convey("Then the page should have the area type bool set to true", func() {
+					mockFilter := NewMockFilterClient(mockCtrl)
+					mockFilter.EXPECT().
+						GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.Model{}, "", nil).
+						AnyTimes()
+					mockFilter.
+						EXPECT().
+						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(stubAreaTypeDimension, "", nil).
+						AnyTimes()
+
+					mockDimension := NewMockDimensionClient(mockCtrl)
+					mockDimension.EXPECT().
+						GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(dimension.GetAreaTypesResponse{}, nil)
+
+					mockRend := NewMockRenderClient(mockCtrl)
+					mockRend.EXPECT().
+						NewBasePageModel().
+						Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+						AnyTimes()
+
+					mockRend.
+						EXPECT().
+						// Assert that the area type boolean is true
+						BuildPage(gomock.Any(), pageIsAreaType{true}, gomock.Any())
+
+					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockDimension))
+
+					Convey("And the status code should be 200", func() {
+						So(w.Code, ShouldEqual, http.StatusOK)
+					})
+				})
+			})
+
+			Convey("Given a truthy error query param", func() {
+				req := httptest.NewRequest(http.MethodGet, "/filters/1234/dimensions/city?error=true", nil)
+
+				Convey("Then the page should contain a populated error", func() {
+					mockFilter := NewMockFilterClient(mockCtrl)
+					mockFilter.
+						EXPECT().
+						GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.Model{}, "", nil)
+					mockFilter.
+						EXPECT().
+						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.Dimension{IsAreaType: toBoolPtr(true)}, "", nil).
+						AnyTimes()
+
+					mockDimension := NewMockDimensionClient(mockCtrl)
+					mockDimension.EXPECT().
+						GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(dimension.GetAreaTypesResponse{}, nil).
+						AnyTimes()
+
+					mockRend := NewMockRenderClient(mockCtrl)
+					mockRend.
+						EXPECT().
+						NewBasePageModel().
+						Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+						AnyTimes()
+
+					mockRend.
+						EXPECT().
+						// Confirm the page contains an error
+						BuildPage(gomock.Any(), pageHasError{true}, gomock.Any())
+
+					selector := DimensionsSelector(mockRend, mockFilter, mockDimension)
+
+					w := httptest.NewRecorder()
+					router := mux.NewRouter()
+					router.HandleFunc("/filters/{filterID}/dimensions/{name}", selector)
+					router.ServeHTTP(w, req)
+
+					Convey("And the status code should be 200", func() {
+						So(w.Code, ShouldEqual, http.StatusOK)
+					})
+				})
+			})
+
+			Convey("When the dimension API responds with an error", func() {
+				mockFilter := NewMockFilterClient(mockCtrl)
+				mockFilter.EXPECT().
+					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Model{}, "", nil)
+				mockFilter.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(stubAreaTypeDimension, "", nil).
+					AnyTimes()
+
+				mockDimension := NewMockDimensionClient(mockCtrl)
+				mockDimension.EXPECT().
+					GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(dimension.GetAreaTypesResponse{}, errors.New("oh no"))
+
+				mockRend := NewMockRenderClient(mockCtrl)
+				mockRend.EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+					AnyTimes()
+
+				w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockDimension))
+
+				Convey("Then the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+		})
+	})
+}
+
+func runDimensionsSelector(dimension string, selector func(http.ResponseWriter, *http.Request)) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/filters/1234/dimensions/%s", dimension), nil)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/filters/{filterID}/dimensions/{name}", selector)
+
+	router.ServeHTTP(w, req)
+
+	return w
+}
+
+// pageMatchesSelections is a gomock matcher that confirms a selection page
+// contains the correct selections (i.e. radio buttons).
+type pageMatchesSelections struct {
+	selections []model.Selection
+}
+
+func (c pageMatchesSelections) Matches(x interface{}) bool {
+	page, ok := x.(model.Selector)
+	if !ok {
+		return false
+	}
+
+	return reflect.DeepEqual(c.selections, page.Selections)
+}
+
+func (c pageMatchesSelections) String() string {
+	return fmt.Sprintf("is equal to %+v", c.selections)
+}
+
+// pageMatchesSelections is a gomock matcher that confirms a selection page
+// has the correct page title.
+type pageHasTitle struct {
+	title string
+}
+
+func (p pageHasTitle) Matches(x interface{}) bool {
+	page, ok := x.(model.Selector)
+	if !ok {
+		return false
+	}
+
+	return p.title == page.Page.Metadata.Title
+}
+
+func (p pageHasTitle) String() string {
+	return fmt.Sprintf("title is equal to \"%s\"", p.title)
+}
+
+// pageIsAreaType is a gomock matcher that confirms a selection page
+// `IsAreaType` boolean is set to the expected value.
+type pageIsAreaType struct {
+	expected bool
+}
+
+func (c pageIsAreaType) Matches(x interface{}) bool {
+	page, ok := x.(model.Selector)
+	if !ok {
+		return false
+	}
+
+	return page.IsAreaType == c.expected
+}
+
+func (c pageIsAreaType) String() string {
+	return fmt.Sprintf("is equal to %+v", c.expected)
+}
+
+// pageHasError is a gomock matcher that confirms a selection page
+// has a populated error.
+type pageHasError struct {
+	expected bool
+}
+
+func (p pageHasError) Matches(x interface{}) bool {
+	page, ok := x.(model.Selector)
+	if !ok {
+		return false
+	}
+
+	if p.expected {
+		return page.Error.Title != ""
+	}
+
+	return page.Error.Title == ""
+}
+
+func (p pageHasError) String() string {
+	return fmt.Sprintf("is equal to %+v", p.expected)
+}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -5,10 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"reflect"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
@@ -68,12 +65,15 @@ func TestUnitHandlers(t *testing.T) {
 
 	Convey("test filter flex overview", t, func() {
 		Convey("test filter flex overview page is successful", func() {
+			mockDatasetDims := dataset.VersionDimensions{
+				Items: []dataset.VersionDimension{},
+			}
 			Convey("options on filter job no additional call to get options", func() {
 				mockRend := NewMockRenderClient(mockCtrl)
 				mockDc := NewMockDatasetClient(mockCtrl)
 
 				mockFc := NewMockFilterClient(mockCtrl)
-				dims := filter.Dimensions{
+				mockFilterDims := filter.Dimensions{
 					Items: []filter.Dimension{
 						{
 							Name:       "Test",
@@ -85,8 +85,9 @@ func TestUnitHandlers(t *testing.T) {
 				mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
 				mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), "overview")
 				mockFc.EXPECT().GetFilter(ctx, gomock.Any()).Return(&filter.GetFilterResponse{}, nil)
-				mockFc.EXPECT().GetDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(dims, "", nil)
-				mockFc.EXPECT().GetDimension(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(dims.Items[0], "", nil)
+				mockFc.EXPECT().GetDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFilterDims, "", nil)
+				mockFc.EXPECT().GetDimension(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFilterDims.Items[0], "", nil)
+				mockDc.EXPECT().GetVersionDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDatasetDims, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -119,6 +120,7 @@ func TestUnitHandlers(t *testing.T) {
 				mockFc.EXPECT().GetDimension(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(dims.Items[0], "", nil)
 				mockDc.EXPECT().GetOptions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), "", "", "0", dims.Items[0].Name,
 					&dataset.QueryParams{Offset: 0, Limit: 1000}).Return(mockOpts[0], nil)
+				mockDc.EXPECT().GetVersionDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDatasetDims, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -227,10 +229,16 @@ func TestUnitHandlers(t *testing.T) {
 							BuildPage(gomock.Any(), gomock.Any(), "overview").
 							AnyTimes()
 
+						mockDc := NewMockDatasetClient(mockCtrl)
+						mockDc.
+							EXPECT().
+							GetVersionDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(mockDatasetDims, nil)
+
 						w := httptest.NewRecorder()
 						req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-						FilterFlexOverview(mockRend, mockFc, NewMockDatasetClient(mockCtrl), mockDimsc).
+						FilterFlexOverview(mockRend, mockFc, mockDc, mockDimsc).
 							ServeHTTP(w, req)
 
 						Convey("Then the status code should be 200", func() {
@@ -302,10 +310,16 @@ func TestUnitHandlers(t *testing.T) {
 							EXPECT().
 							BuildPage(gomock.Any(), pageMatchesOverviewDimensions{dimensions: expPageDimensions}, "overview")
 
+						mockDc := NewMockDatasetClient(mockCtrl)
+						mockDc.
+							EXPECT().
+							GetVersionDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(mockDatasetDims, nil)
+
 						w := httptest.NewRecorder()
 						req := httptest.NewRequest(http.MethodGet, "/test", nil)
 
-						FilterFlexOverview(mockRend, mockFc, NewMockDatasetClient(mockCtrl), mockDimsc).
+						FilterFlexOverview(mockRend, mockFc, mockDc, mockDimsc).
 							ServeHTTP(w, req)
 
 						Convey("Then the status code should be 200", func() {
@@ -334,548 +348,39 @@ func TestUnitHandlers(t *testing.T) {
 
 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 			})
-		})
-	})
 
-	Convey("Dimensions Selector", t, func() {
-		Convey("Given a valid dimension param for a filter", func() {
-			Convey("Then the page title contains the dimension name", func() {
-				const dimensionName = "Number Of Siblings"
-
-				mockFilter := NewMockFilterClient(mockCtrl)
-				mockFilter.
-					EXPECT().
-					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Model{}, "", nil)
-				mockFilter.
-					EXPECT().
-					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Dimension{Name: dimensionName}, "", nil).
-					AnyTimes()
-
-				mockRend := NewMockRenderClient(mockCtrl)
-				mockRend.
-					EXPECT().
-					NewBasePageModel().
-					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-					AnyTimes()
-
-				mockRend.
-					EXPECT().
-					BuildPage(gomock.Any(), pageHasTitle{dimensionName}, gomock.Any())
-
-				w := runDimensionsSelector(
-					"number+of+siblings",
-					DimensionsSelector(mockRend, mockFilter, NewMockDimensionClient(mockCtrl)),
-				)
-
-				Convey("And the status code should be 200", func() {
-					So(w.Code, ShouldEqual, http.StatusOK)
-				})
-			})
-		})
-
-		Convey("Given a dimension param which is missing from a filter", func() {
-			mockFilter := NewMockFilterClient(mockCtrl)
-			mockFilter.
-				EXPECT().
-				GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(filter.Model{}, "", nil) // No filter dimensions
-			mockFilter.
-				EXPECT().
-				GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(filter.Dimension{}, "", &filter.ErrInvalidFilterAPIResponse{ExpectedCode: http.StatusOK, ActualCode: http.StatusNotFound}).
-				AnyTimes()
-
-			w := runDimensionsSelector(
-				"city",
-				DimensionsSelector(NewMockRenderClient(mockCtrl), mockFilter, NewMockDimensionClient(mockCtrl)),
-			)
-
-			Convey("Then the status code should be 404", func() {
-				So(w.Code, ShouldEqual, http.StatusNotFound)
-			})
-		})
-
-		Convey("Given a dimension param which is not an area type", func() {
-			const dimensionName = "siblings"
-
-			stubDimension := filter.Dimension{
-				Name:       dimensionName,
-				IsAreaType: toBoolPtr(false),
-			}
-
-			// This will change, but represents the current non-area-type behaviour.
-			Convey("Then the page should contain no selections", func() {
-				mockFilter := NewMockFilterClient(mockCtrl)
-				mockFilter.
-					EXPECT().
-					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Model{}, "", nil).
-					AnyTimes()
-				mockFilter.
-					EXPECT().
-					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(stubDimension, "", nil).
-					AnyTimes()
-
-				mockRend := NewMockRenderClient(mockCtrl)
-				mockRend.
-					EXPECT().
-					NewBasePageModel().
-					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-					AnyTimes()
-
-				mockRend.
-					EXPECT().
-					// Assert that there are no selections passed to BuildPage
-					BuildPage(gomock.Any(), pageMatchesSelections{}, gomock.Any())
-
-				w := runDimensionsSelector(
-					dimensionName,
-					DimensionsSelector(mockRend, mockFilter, NewMockDimensionClient(mockCtrl)),
-				)
-
-				Convey("And the status code should be 200", func() {
-					So(w.Code, ShouldEqual, http.StatusOK)
-				})
-			})
-
-			Convey("Then the page should have the area type bool set to false", func() {
-				mockFilter := NewMockFilterClient(mockCtrl)
-				mockFilter.
-					EXPECT().
-					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Model{}, "", nil).
-					AnyTimes()
-				mockFilter.
-					EXPECT().
-					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(stubDimension, "", nil).
-					AnyTimes()
-
-				mockRend := NewMockRenderClient(mockCtrl)
-				mockRend.
-					EXPECT().
-					NewBasePageModel().
-					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-					AnyTimes()
-
-				mockRend.
-					EXPECT().
-					// Assert that the area type boolean is false
-					BuildPage(gomock.Any(), pageIsAreaType{false}, gomock.Any())
-
-				w := runDimensionsSelector(
-					dimensionName,
-					DimensionsSelector(mockRend, mockFilter, NewMockDimensionClient(mockCtrl)),
-				)
-
-				Convey("And the status code should be 200", func() {
-					So(w.Code, ShouldEqual, http.StatusOK)
-				})
-			})
-
-			Convey("Then the dimensions API should be queried using the dimension name", func() {
-				mockFilter := NewMockFilterClient(mockCtrl)
-				mockFilter.
-					EXPECT().
-					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Model{}, "", nil).
-					AnyTimes()
-				mockFilter.
-					EXPECT().
-					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), "siblings").
-					Return(stubDimension, "", nil).
-					AnyTimes()
-
-				mockRend := NewMockRenderClient(mockCtrl)
-				mockRend.
-					EXPECT().
-					NewBasePageModel().
-					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-					AnyTimes()
-
-				mockRend.
-					EXPECT().
-					BuildPage(gomock.Any(), gomock.Any(), gomock.Any())
-
-				w := runDimensionsSelector(
-					dimensionName,
-					DimensionsSelector(mockRend, mockFilter, NewMockDimensionClient(mockCtrl)),
-				)
-
-				Convey("And the status code should be 200", func() {
-					So(w.Code, ShouldEqual, http.StatusOK)
-				})
-			})
-
-			Convey("When the filter API responds with an error", func() {
-				mockFilter := NewMockFilterClient(mockCtrl)
-				mockFilter.EXPECT().
-					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Model{}, "", errors.New("oh no")).
-					AnyTimes()
-
-				w := runDimensionsSelector(
-					dimensionName,
-					DimensionsSelector(NewMockRenderClient(mockCtrl), mockFilter, NewMockDimensionClient(mockCtrl)),
-				)
-
-				Convey("Then the status code should be 500", func() {
-					So(w.Code, ShouldEqual, http.StatusInternalServerError)
-				})
-			})
-		})
-
-		Convey("Given an area type", func() {
-			const dimensionName = "city"
-
-			stubAreaTypeDimension := filter.Dimension{
-				Name:       dimensionName,
-				IsAreaType: toBoolPtr(true),
-			}
-
-			Convey("When area types are returned", func() {
-				Convey("Then the page should contain a list of area type selections", func() {
-					const dimensionID = "city"
-					const dimensionLabel = "City"
-
-					mockFilter := NewMockFilterClient(mockCtrl)
-					mockFilter.EXPECT().
-						GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(filter.Model{}, "", nil).
-						AnyTimes()
-					mockFilter.
-						EXPECT().
-						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(stubAreaTypeDimension, "", nil).
-						AnyTimes()
-
-					mockDimension := NewMockDimensionClient(mockCtrl)
-					mockDimension.EXPECT().
-						GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(
-							dimension.GetAreaTypesResponse{
-								AreaTypes: []dimension.AreaType{{
-									ID:         dimensionID,
-									Label:      dimensionLabel,
-									TotalCount: 1,
-								}},
-							},
-							nil,
-						).
-						AnyTimes()
-
-					mockRend := NewMockRenderClient(mockCtrl)
-					mockRend.EXPECT().
-						NewBasePageModel().
-						Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-						AnyTimes()
-
-					// Validate page data contains selections
-					mockRend.EXPECT().
-						BuildPage(
-							gomock.Any(),
-							pageMatchesSelections{
-								selections: []model.Selection{
-									{
-										Value:      dimensionID,
-										Label:      dimensionLabel,
-										TotalCount: 1,
-									},
-								},
-							},
-							"selector",
-						)
-
-					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockDimension))
-
-					Convey("And the status code should be 200", func() {
-						So(w.Code, ShouldEqual, http.StatusOK)
-					})
-				})
-
-				Convey("Then the dimensions API client should request area types using the cantabular ID", func() {
-					const cantabularID = "cantabular"
-
-					mockFilter := NewMockFilterClient(mockCtrl)
-					mockFilter.EXPECT().
-						GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(filter.Model{PopulationType: cantabularID}, "", nil).
-						AnyTimes()
-					mockFilter.
-						EXPECT().
-						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(stubAreaTypeDimension, "", nil).
-						AnyTimes()
-
-					mockDimension := NewMockDimensionClient(mockCtrl)
-					mockDimension.EXPECT().
-						GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), cantabularID).
-						Return(dimension.GetAreaTypesResponse{}, nil)
-
-					mockRend := NewMockRenderClient(mockCtrl)
-					mockRend.EXPECT().
-						NewBasePageModel().
-						Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-						AnyTimes()
-
-					mockRend.
-						EXPECT().
-						BuildPage(gomock.Any(), gomock.Any(), "selector").
-						AnyTimes()
-
-					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockDimension))
-
-					Convey("And the status code should be 200", func() {
-						So(w.Code, ShouldEqual, http.StatusOK)
-					})
-				})
-
-				Convey("Then the page should have the area type bool set to true", func() {
-					mockFilter := NewMockFilterClient(mockCtrl)
-					mockFilter.EXPECT().
-						GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(filter.Model{}, "", nil).
-						AnyTimes()
-					mockFilter.
-						EXPECT().
-						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(stubAreaTypeDimension, "", nil).
-						AnyTimes()
-
-					mockDimension := NewMockDimensionClient(mockCtrl)
-					mockDimension.EXPECT().
-						GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(dimension.GetAreaTypesResponse{}, nil)
-
-					mockRend := NewMockRenderClient(mockCtrl)
-					mockRend.EXPECT().
-						NewBasePageModel().
-						Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-						AnyTimes()
-
-					mockRend.
-						EXPECT().
-						// Assert that the area type boolean is true
-						BuildPage(gomock.Any(), pageIsAreaType{true}, gomock.Any())
-
-					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockDimension))
-
-					Convey("And the status code should be 200", func() {
-						So(w.Code, ShouldEqual, http.StatusOK)
-					})
-				})
-			})
-
-			Convey("Given a truthy error query param", func() {
-				req := httptest.NewRequest(http.MethodGet, "/filters/1234/dimensions/city?error=true", nil)
-
-				Convey("Then the page should contain a populated error", func() {
-					mockFilter := NewMockFilterClient(mockCtrl)
-					mockFilter.
-						EXPECT().
-						GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(filter.Model{}, "", nil)
-					mockFilter.
-						EXPECT().
-						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(filter.Dimension{IsAreaType: toBoolPtr(true)}, "", nil).
-						AnyTimes()
-
-					mockDimension := NewMockDimensionClient(mockCtrl)
-					mockDimension.EXPECT().
-						GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(dimension.GetAreaTypesResponse{}, nil).
-						AnyTimes()
-
-					mockRend := NewMockRenderClient(mockCtrl)
-					mockRend.
-						EXPECT().
-						NewBasePageModel().
-						Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-						AnyTimes()
-
-					mockRend.
-						EXPECT().
-						// Confirm the page contains an error
-						BuildPage(gomock.Any(), pageHasError{true}, gomock.Any())
-
-					selector := DimensionsSelector(mockRend, mockFilter, mockDimension)
-
-					w := httptest.NewRecorder()
-					router := mux.NewRouter()
-					router.HandleFunc("/filters/{filterID}/dimensions/{name}", selector)
-					router.ServeHTTP(w, req)
-
-					Convey("And the status code should be 200", func() {
-						So(w.Code, ShouldEqual, http.StatusOK)
-					})
-				})
-			})
-
-			Convey("When the dimension API responds with an error", func() {
-				mockFilter := NewMockFilterClient(mockCtrl)
-				mockFilter.EXPECT().
-					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Model{}, "", nil)
-				mockFilter.
-					EXPECT().
-					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(stubAreaTypeDimension, "", nil).
-					AnyTimes()
-
-				mockDimension := NewMockDimensionClient(mockCtrl)
-				mockDimension.EXPECT().
-					GetAreaTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(dimension.GetAreaTypesResponse{}, errors.New("oh no"))
-
-				mockRend := NewMockRenderClient(mockCtrl)
-				mockRend.EXPECT().
-					NewBasePageModel().
-					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
-					AnyTimes()
-
-				w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockDimension))
-
-				Convey("Then the status code should be 500", func() {
-					So(w.Code, ShouldEqual, http.StatusInternalServerError)
-				})
+			Convey("test FilterFlexOverview returns 500 if client GetVersionDimensions returns an error", func() {
+				mockFc := NewMockFilterClient(mockCtrl)
+				mockDc := NewMockDatasetClient(mockCtrl)
+				mockDimsC := NewMockDimensionClient(mockCtrl)
+
+				mockFilterDims := filter.Dimensions{
+					Items: []filter.Dimension{
+						{
+							Name:       "Test",
+							IsAreaType: new(bool),
+							Options:    []string{"an option", "and another"},
+						},
+					},
+				}
+
+				mockFc.EXPECT().GetFilter(ctx, gomock.Any()).Return(&filter.GetFilterResponse{}, nil)
+				mockFc.EXPECT().GetDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFilterDims, "", nil)
+				mockFc.EXPECT().GetDimension(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFilterDims.Items[0], "", nil)
+				mockDc.EXPECT().GetVersionDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(dataset.VersionDimensions{}, errors.New("sorry"))
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
+
+				router := mux.NewRouter()
+				router.HandleFunc("/filters/12345/dimensions", FilterFlexOverview(mockRend, mockFc, mockDc, mockDimsC))
+
+				router.ServeHTTP(w, req)
+
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 			})
 		})
 	})
-
-	Convey("Change dimension", t, func() {
-		stubFormData := url.Values{}
-		stubFormData.Add("dimension", "country")
-		stubFormData.Add("is_area_type", "true")
-
-		Convey("Given a valid dimension", func() {
-			Convey("When the user is redirected to the dimensions review screen", func() {
-				const filterID = "1234"
-
-				filterClient := NewMockFilterClient(mockCtrl)
-				filterClient.
-					EXPECT().
-					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Dimension{}, "", nil).
-					AnyTimes()
-
-				w := runChangeDimension(filterID, "city", stubFormData, ChangeDimension(filterClient))
-
-				Convey("Then the location header should match the review screen", func() {
-					So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/filters/%s/dimensions", filterID))
-				})
-
-				Convey("And the status code should be 301", func() {
-					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
-				})
-			})
-
-			Convey("When the filter client's `UpdateDimensions` method is called, it is passed the new dimension", func() {
-				const filterID = "1234"
-				const dimensionName = "geography"
-				const newDimension = "country"
-
-				expDimension := filter.Dimension{
-					Name:       "geography",
-					ID:         newDimension,
-					IsAreaType: toBoolPtr(true),
-				}
-
-				filterClient := NewMockFilterClient(mockCtrl)
-				filterClient.
-					EXPECT().
-					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), filterID, dimensionName, gomock.Any(), gomock.Eq(expDimension)).
-					Return(filter.Dimension{}, "", nil)
-
-				formData := url.Values{}
-				formData.Add("dimension", newDimension)
-				formData.Add("is_area_type", "true")
-
-				runChangeDimension(filterID, dimensionName, formData, ChangeDimension(filterClient))
-			})
-
-			Convey("When the filter API client responds with an error", func() {
-				filterClient := NewMockFilterClient(mockCtrl)
-				filterClient.
-					EXPECT().
-					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.Dimension{}, "", errors.New("internal error"))
-
-				w := runChangeDimension("test", "test", stubFormData, ChangeDimension(filterClient))
-
-				Convey("Then the client should not be redirected", func() {
-					So(w.Header().Get("Location"), ShouldBeEmpty)
-				})
-
-				Convey("And the status code should be 500", func() {
-					So(w.Code, ShouldEqual, http.StatusInternalServerError)
-				})
-			})
-		})
-
-		Convey("Given an invalid request", func() {
-			Convey("When the area type has not been provided", func() {
-				formData := url.Values{}
-				formData.Add("is_area_type", "true")
-
-				w := runChangeDimension("test", "test", formData, ChangeDimension(NewMockFilterClient(mockCtrl)))
-
-				Convey("Then the client should be redirected with the error query param", func() {
-					location := w.Header().Get("Location")
-					So(location, ShouldNotBeEmpty)
-
-					parse, err := url.Parse(location)
-					So(err, ShouldBeNil)
-
-					query := parse.Query()
-					So(query["error"], ShouldNotBeEmpty)
-				})
-
-				Convey("And the status code should be 301", func() {
-					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
-				})
-			})
-
-			Convey("When the request is missing the hidden required form values", func() {
-				tests := map[string]url.Values{
-					"Missing is_area_type":       {"dimension": []string{"country"}},
-					"Invalid is_area_type value": {"dimension": []string{"country"}, "is_area_type": []string{"no"}},
-				}
-
-				for name, formData := range tests {
-					Convey(name, func() {
-						w := runChangeDimension("test", "test", formData, ChangeDimension(NewMockFilterClient(mockCtrl)))
-
-						Convey("Then the client should not be redirected", func() {
-							So(w.Header().Get("Location"), ShouldBeEmpty)
-						})
-
-						Convey("And the status code should be 400", func() {
-							So(w.Code, ShouldEqual, http.StatusBadRequest)
-						})
-					})
-				}
-			})
-		})
-	})
-}
-
-func runChangeDimension(filterID, dimension string, formData url.Values, handler http.HandlerFunc) *httptest.ResponseRecorder {
-	encodedFormData := formData.Encode()
-	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/filters/%s/dimensions/%s", filterID, dimension), strings.NewReader(encodedFormData))
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Content-Length", strconv.Itoa(len(encodedFormData)))
-
-	w := httptest.NewRecorder()
-
-	router := mux.NewRouter()
-	router.HandleFunc("/filters/{filterID}/dimensions/{name}", handler)
-	router.ServeHTTP(w, req)
-
-	return w
 }
 
 func initialiseMockConfig() config.Config {
@@ -884,98 +389,6 @@ func initialiseMockConfig() config.Config {
 		SiteDomain:               "ons",
 		SupportedLanguages:       []string{"en", "cy"},
 	}
-}
-
-func runDimensionsSelector(dimension string, selector func(http.ResponseWriter, *http.Request)) *httptest.ResponseRecorder {
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", fmt.Sprintf("/filters/1234/dimensions/%s", dimension), nil)
-
-	router := mux.NewRouter()
-	router.HandleFunc("/filters/{filterID}/dimensions/{name}", selector)
-
-	router.ServeHTTP(w, req)
-
-	return w
-}
-
-// pageMatchesSelections is a gomock matcher that confirms a selection page
-// contains the correct selections (i.e. radio buttons).
-type pageMatchesSelections struct {
-	selections []model.Selection
-}
-
-func (c pageMatchesSelections) Matches(x interface{}) bool {
-	page, ok := x.(model.Selector)
-	if !ok {
-		return false
-	}
-
-	return reflect.DeepEqual(c.selections, page.Selections)
-}
-
-func (c pageMatchesSelections) String() string {
-	return fmt.Sprintf("is equal to %+v", c.selections)
-}
-
-// pageMatchesSelections is a gomock matcher that confirms a selection page
-// has the correct page title.
-type pageHasTitle struct {
-	title string
-}
-
-func (p pageHasTitle) Matches(x interface{}) bool {
-	page, ok := x.(model.Selector)
-	if !ok {
-		return false
-	}
-
-	return p.title == page.Page.Metadata.Title
-}
-
-func (p pageHasTitle) String() string {
-	return fmt.Sprintf("title is equal to \"%s\"", p.title)
-}
-
-// pageIsAreaType is a gomock matcher that confirms a selection page
-// `IsAreaType` boolean is set to the expected value.
-type pageIsAreaType struct {
-	expected bool
-}
-
-func (c pageIsAreaType) Matches(x interface{}) bool {
-	page, ok := x.(model.Selector)
-	if !ok {
-		return false
-	}
-
-	return page.IsAreaType == c.expected
-}
-
-func (c pageIsAreaType) String() string {
-	return fmt.Sprintf("is equal to %+v", c.expected)
-}
-
-// pageHasError is a gomock matcher that confirms a selection page
-// has a populated error.
-type pageHasError struct {
-	expected bool
-}
-
-func (p pageHasError) Matches(x interface{}) bool {
-	page, ok := x.(model.Selector)
-	if !ok {
-		return false
-	}
-
-	if p.expected {
-		return page.Error.Title != ""
-	}
-
-	return page.Error.Title == ""
-}
-
-func (p pageHasError) String() string {
-	return fmt.Sprintf("is equal to %+v", p.expected)
 }
 
 // pageMatchesOverviewDimensions is a gomock matcher that confirms a review page

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -272,6 +272,21 @@ func (mr *MockDatasetClientMockRecorder) GetOptions(ctx, userAuthToken, serviceA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*MockDatasetClient)(nil).GetOptions), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, q)
 }
 
+// GetVersionDimensions mocks base method.
+func (m *MockDatasetClient) GetVersionDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (dataset.VersionDimensions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVersionDimensions", ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version)
+	ret0, _ := ret[0].(dataset.VersionDimensions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVersionDimensions indicates an expected call of GetVersionDimensions.
+func (mr *MockDatasetClientMockRecorder) GetVersionDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersionDimensions", reflect.TypeOf((*MockDatasetClient)(nil).GetVersionDimensions), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version)
+}
+
 // MockDimensionClient is a mock of DimensionClient interface.
 type MockDimensionClient struct {
 	ctrl     *gomock.Controller

--- a/handlers/submit.go
+++ b/handlers/submit.go
@@ -53,6 +53,6 @@ func submit(w http.ResponseWriter, req *http.Request, accessToken, collectionID 
 	dsID := dataset.DatasetID
 	ed := dataset.Edition
 	v := strconv.Itoa(dataset.Version)
-	foID := resp.Links.FilterOutputs.ID
+	foID := resp.FilterOutputID
 	http.Redirect(w, req, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-outputs/%s", dsID, ed, v, foID), http.StatusFound)
 }

--- a/handlers/submit_test.go
+++ b/handlers/submit_test.go
@@ -29,7 +29,7 @@ func TestSubmitHandler(t *testing.T) {
 				},
 			}
 			mockFilterResp := &filter.SubmitFilterResponse{}
-			mockFilterResp.Links.FilterOutputs.ID = "abcde12345"
+			mockFilterResp.FilterOutputID = "abcde12345"
 			mockFc.EXPECT().GetFilter(ctx, gomock.Any()).Return(mockFilter, nil)
 			mockFc.EXPECT().SubmitFilter(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFilterResp, "", nil)
 


### PR DESCRIPTION
### What

- Populated collapsible UI with data from dataset client 
- Refactored `handlers` tests into separate test files (lift and shift)
- Update api clients which fixes the `FilterOutputId` field not populating

### How to review

- Sense check
- Tests pass
- Review image and `data.json`
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. 
  - Create a dataset with metadata in the dimension description field(s) in Florence
  - Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-example/editions/2021/versions/1)
  - Click 'change' 
  - Navigate 'back' to the summary page; should be something like `http://localhost:8081/filters/c039f4c7-a486-4511-85c8-0796e6743563/dimensions` 
  - Check the collapsible has real data 
  - **OR** call me 🤙 and I'll show you 

#### Image
<img width="394" alt="populated collapsible" src="https://user-images.githubusercontent.com/19624419/169013801-c3989d09-771f-49c5-9091-c17540e8fb27.png">

#### Data
```json
{
    "count": 2,
    "items": [
        {
            "description": "The age",
            "label": "Age",
            "links": {
                "code_list": {
                    "href": "http://api.localhost:23200/v1/code-lists/Age",
                    "id": "Age"
                },
                "options": {
                    "href": "http://api.localhost:23200/v1/datasets/Testing-server-v2/editions/2021/versions/1/dimensions/age/options",
                    "id": "age"
                },
                "version": {
                    "href": "http://api.localhost:23200/v1/datasets/Testing-server-v2/editions/2021/versions/1"
                }
            },
            "name": "age"
        },
        {
            "description": "The region",
            "label": "Region",
            "links": {
                "code_list": {
                    "href": "http://api.localhost:23200/v1/code-lists/Region",
                    "id": "Region"
                },
                "options": {
                    "href": "http://api.localhost:23200/v1/datasets/Testing-server-v2/editions/2021/versions/1/dimensions/geography/options",
                    "id": "geography"
                },
                "version": {
                    "href": "http://api.localhost:23200/v1/datasets/Testing-server-v2/editions/2021/versions/1"
                }
            },
            "name": "geography"
        }
    ],
    "limit": 20,
    "offset": 0,
    "total_count": 2
}
```

### Who can review

Frontend go dev
