### PR TITLE
Fix/remove margin on list item

### DIFF
--- a/assets/templates/partials/summary.tmpl
+++ b/assets/templates/partials/summary.tmpl
@@ -35,7 +35,7 @@
                                         <ul class="ons-list{{ if $isTruncated }}--truncated{{end}}{{ if or (gt $length 9) ($isTruncated) }} ons-u-mb-xs{{else}}
                                                 ons-u-m-no{{end}}">
                                             {{ range $i, $opt := .Options }}
-                                                <li class="ons-list__item{{ if $isTruncated }}--truncated{{end}}">
+                                                <li class="ons-list__item{{ if $isTruncated }}--truncated{{end}} ons-u-mb-no">
                                                     {{ . }}
                                                 </li>
                                             {{ end }}


### PR DESCRIPTION
### What

Removed margin bottom on `ons-list__item` with utility class `ons-u-mb-no`

### How to review

Sense check
L👀k at before and after images 

#### Before
<img width="362" alt="before with margin" src="https://user-images.githubusercontent.com/19624419/172651119-57726257-b885-4cf8-af90-a731af32ac64.png">

#### After
<img width="362" alt="after without margin" src="https://user-images.githubusercontent.com/19624419/172651260-bc885673-b045-4339-a26f-7110c32cc5d5.png">

### Who can review

Frontend dev
