### PR TITLE
Feature/create handler for get coverage

### DIFF
--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -1,0 +1,11 @@
+<div class="ons-page__container ons-container">
+    <div class="ons-grid ons-u-ml-no">
+        {{ template "partials/breadcrumb" . }}
+        <h1 class="ons-u-fs-xxxl ons-u-mt-s ons-u-fw-b">{{ .Page.Metadata.Title }}</h1>
+        <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
+            <div class="ons-page__main ons-u-mt-l">
+                
+            </div>
+        </div>
+    </div>
+</div>

--- a/handlers/get_coverage.go
+++ b/handlers/get_coverage.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mapper"
+	"github.com/ONSdigital/dp-net/v2/handlers"
+	"github.com/gorilla/mux"
+)
+
+func GetCoverage(rc RenderClient) http.HandlerFunc {
+	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
+		getCoverage(w, req, rc, lang, accessToken, collectionID)
+	})
+}
+
+func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, lang, accessToken, collectionID string) {
+	vars := mux.Vars(req)
+	filterID := vars["filterID"]
+	basePage := rc.NewBasePageModel()
+	m := mapper.CreateGetCoverage(req, basePage, lang, filterID)
+	rc.BuildPage(w, m, "coverage")
+}

--- a/handlers/get_coverage_test.go
+++ b/handlers/get_coverage_test.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mocks"
+	"github.com/ONSdigital/dp-renderer/helper"
+	coreModel "github.com/ONSdigital/dp-renderer/model"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetCoverageHandler(t *testing.T) {
+	helper.InitialiseLocalisationsHelper(mocks.MockAssetFunction)
+	mockCtrl := gomock.NewController(t)
+	cfg := initialiseMockConfig()
+
+	Convey("Get coverage", t, func() {
+		Convey("Given a valid request", func() {
+			Convey("When the user is redirected to the change coverage screen", func() {
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage", nil)
+
+				rend := NewMockRenderClient(mockCtrl)
+				rend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
+				rend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), "coverage")
+
+				router := mux.NewRouter()
+				router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(rend))
+				router.ServeHTTP(w, req)
+
+				Convey("And the status code should be 200", func() {
+					So(w.Code, ShouldEqual, http.StatusOK)
+				})
+			})
+		})
+	})
+}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -26,12 +26,7 @@ func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, 
 	p := model.Overview{
 		Page: basePage,
 	}
-	mapCookiePreferences(req, &p.Page.CookiesPreferencesSet, &p.Page.CookiesPolicy)
-
-	p.BetaBannerEnabled = true
-	p.Type = "filter-flex-overview"
-	p.Metadata.Title = "Review changes"
-	p.Language = lang
+	mapCommonProps(req, &p.Page, "filter-flex-overview", "Review changes", lang)
 	p.FilterID = filterJob.FilterID
 	dataset := filterJob.Dataset
 
@@ -119,13 +114,7 @@ func CreateSelector(req *http.Request, basePage coreModel.Page, dimName, lang, f
 	p := model.Selector{
 		Page: basePage,
 	}
-	mapCookiePreferences(req, &p.Page.CookiesPreferencesSet, &p.Page.CookiesPolicy)
-
-	p.BetaBannerEnabled = true
-	p.Type = "filter-flex-selector"
-	p.Metadata.Title = strings.Title(dimName)
-	p.Language = lang
-
+	mapCommonProps(req, &p.Page, "filter-flex-selector", strings.Title(dimName), lang)
 	p.Breadcrumb = []coreModel.TaxonomyNode{
 		{
 			Title: helper.Localise("Back", lang, 1),
@@ -136,10 +125,10 @@ func CreateSelector(req *http.Request, basePage coreModel.Page, dimName, lang, f
 	return p
 }
 
-// CreateAreaTypeSelector maps data to the Overview model
+// CreateAreaTypeSelector maps data to the Selector model
 func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, filterID string, areaType []population.AreaType, fDim filter.Dimension, isValidationError bool) model.Selector {
 	p := CreateSelector(req, basePage, fDim.Label, lang, filterID)
-	p.Page.Metadata.Title = "Area Type"
+	p.Page.Metadata.Title = "Area type"
 
 	if isValidationError {
 		p.Page.Error = coreModel.Error{
@@ -161,6 +150,31 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, fi
 	p.IsAreaType = true
 
 	return p
+}
+
+// CreateGetCoverage maps data to the coverage model
+func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID string) model.Coverage {
+	p := model.Coverage{
+		Page: basePage,
+	}
+	mapCommonProps(req, &p.Page, "filter-flex-coverage", "Coverage", lang)
+	p.Breadcrumb = []coreModel.TaxonomyNode{
+		{
+			Title: helper.Localise("Back", lang, 1),
+			URI:   fmt.Sprintf("/filters/%s/dimensions", filterID),
+		},
+	}
+
+	return p
+}
+
+// mapCommonProps maps common properties on all filter/flex pages
+func mapCommonProps(req *http.Request, p *coreModel.Page, pageType, title, lang string) {
+	mapCookiePreferences(req, &p.CookiesPreferencesSet, &p.CookiesPolicy)
+	p.BetaBannerEnabled = true
+	p.Type = pageType
+	p.Metadata.Title = title
+	p.Language = lang
 }
 
 // mapCookiePreferences reads cookie policy and preferences cookies and then maps the values to the page model

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -207,8 +207,8 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 			So(changeDimension.Language, ShouldEqual, lang)
 		})
 
-		Convey("it sets the title to Area Type", func() {
-			So(changeDimension.Metadata.Title, ShouldEqual, "Area Type")
+		Convey("it sets the title to Area type", func() {
+			So(changeDimension.Metadata.Title, ShouldEqual, "Area type")
 		})
 
 		Convey("it sets IsAreaType to true", func() {
@@ -232,6 +232,25 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 
 		Convey("it returns a populated error", func() {
 			So(changeDimension.Error.Title, ShouldNotBeEmpty)
+		})
+	})
+}
+
+func TestGetCoverage(t *testing.T) {
+	helper.InitialiseLocalisationsHelper(mocks.MockAssetFunction)
+	Convey("Given a valid page", t, func() {
+		const lang = "en"
+		req := httptest.NewRequest("", "/", nil)
+		coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345")
+
+		Convey("it sets page metadata", func() {
+			So(coverage.BetaBannerEnabled, ShouldBeTrue)
+			So(coverage.Type, ShouldEqual, "filter-flex-coverage")
+			So(coverage.Language, ShouldEqual, lang)
+		})
+
+		Convey("it sets the title to Coverage", func() {
+			So(coverage.Metadata.Title, ShouldEqual, "Coverage")
 		})
 	})
 }

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -1,0 +1,10 @@
+package model
+
+import (
+	coreModel "github.com/ONSdigital/dp-renderer/model"
+)
+
+// Coverage represents the data to display the coverage page
+type Coverage struct {
+	coreModel.Page
+}

--- a/model/overview.go
+++ b/model/overview.go
@@ -4,6 +4,7 @@ import (
 	coreModel "github.com/ONSdigital/dp-renderer/model"
 )
 
+// Overview represents the data to display the overview page
 type Overview struct {
 	coreModel.Page
 	FilterID   string      `json:"filter_id"`

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -36,4 +36,5 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(handlers.FilterFlexOverview(c.Render, c.Filter, c.Dataset, c.Dimension))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(handlers.DimensionsSelector(c.Render, c.Filter, c.Population))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("POST").HandlerFunc(handlers.ChangeDimension(c.Filter))
+	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/geography/coverage").Methods("GET").HandlerFunc(handlers.GetCoverage(c.Render))
 }


### PR DESCRIPTION
### What

Skeleton code to handle get coverage page
- Handler
- Route path
- Mapper function
  - Refactored mapping common props
- Unit tests
- Template

### How to review

- Sense check
- Tests pass
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. 
  - Create a flexible dataset
  - Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-example/editions/2021/versions/1)
  - Click 'change' on 'Coverage'
  - You should be redirected to the 'Coverage' page
  - The 'back' link should return to the 'Overview' page but you cannot then return to 'Coverage' => that's coming soon 🤞 
  - **OR** call me 🤙 and I'll show you 

### Who can review

Frontend go dev
