### PR TITLE
Feature/pluralising geography label

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -59,6 +59,61 @@ one = "Select an area type"
 description = "Area type"
 one = "Area type"
 
+[AreaTypeNationalCode]
+description = "National code"
+one = "National code"
+other = "National codes"
+
+[AreaTypeCountryCode]
+description = "Country code"
+one = "Country code"
+other = "Country codes"
+
+[AreaTypeRegionCode]
+description = "Region code"
+one = "Region code"
+other = "Region codes"
+
+[AreaTypeLocalAuthorityCode]
+description = "Local Authority code"
+one = "Local Authority code"
+other = "Local Authority codes"
+
+[AreaTypeMiddleSuperOutputAreaCode]
+description = "Middle Super Output Area code"
+one = "Middle Super Output Area code"
+other = "Middle Super Output Area codes"
+
+[AreaTypeLowerSuperOutputAreaCode]
+description = "Lower Super Output Area code"
+one = "Lower Super Output Area code"
+other = "Lower Super Output Area codes"
+
+[AreaTypeOutputAreaCode]
+description = "Output Area code"
+one = "Output Area code"
+other = "Output Area codes"
+
+[AreaTypeElectoralWardsOrDivision]
+description = "Electoral Wards or Division"
+one = "Electoral Wards or Division"
+other = "Electoral Wards or Divisions"
+
+[AreaTypeCountry]
+description = "Country"
+one = "Country"
+other = "Countries"
+
+[AreaTypeCity]
+description = "City"
+one = "City"
+other = "Cities"
+
+[AreaTypeRegion]
+description = "Region"
+one = "Region"
+other = "Regions"
+
 [CoverageLegend]
 description = "Select the geography you would like your dataset to cover"
 one = "Select the geography you would like your dataset to cover"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -59,6 +59,61 @@ one = "Select an area type"
 description = "Area type"
 one = "Area type"
 
+[AreaTypeNationalCode]
+description = "National code"
+one = "National code"
+other = "National codes"
+
+[AreaTypeCountryCode]
+description = "Country code"
+one = "Country code"
+other = "Country codes"
+
+[AreaTypeRegionCode]
+description = "Region code"
+one = "Region code"
+other = "Region codes"
+
+[AreaTypeLocalAuthorityCode]
+description = "Local Authority code"
+one = "Local Authority code"
+other = "Local Authority codes"
+
+[AreaTypeMiddleSuperOutputAreaCode]
+description = "Middle Super Output Area code"
+one = "Middle Super Output Area code"
+other = "Middle Super Output Area codes"
+
+[AreaTypeLowerSuperOutputAreaCode]
+description = "Lower Super Output Area code"
+one = "Lower Super Output Area code"
+other = "Lower Super Output Area codes"
+
+[AreaTypeOutputAreaCode]
+description = "Output Area code"
+one = "Output Area code"
+other = "Output Area codes"
+
+[AreaTypeElectoralWardsOrDivision]
+description = "Electoral Wards or Division"
+one = "Electoral Wards or Division"
+other = "Electoral Wards or Divisions"
+
+[AreaTypeCountry]
+description = "Country"
+one = "Country"
+other = "Countries"
+
+[AreaTypeCity]
+description = "City"
+one = "City"
+other = "Cities"
+
+[AreaTypeRegion]
+description = "Region"
+one = "Region"
+other = "Regions"
+
 [CoverageLegend]
 description = "Select the geography you would like your dataset to cover"
 one = "Select the geography you would like your dataset to cover"

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -1,7 +1,14 @@
 package helpers
 
 import (
+	"net/http"
 	"net/url"
+	"strings"
+
+	"github.com/ONSdigital/dp-renderer/helper"
+	"github.com/ONSdigital/log.go/v2/log"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // HasStringInSlice checks for a string within in a string array
@@ -28,4 +35,38 @@ func PersistExistingParams(values []string, key, ignoreValue string, q url.Value
 // ToBoolPtr converts a boolean to a pointer
 func ToBoolPtr(val bool) *bool {
 	return &val
+}
+
+/* Pluralise performs a toml file lookup to return the pluralised lookup value from a given key.
+This function is intended not to panic if the toml file lookup fails.
+req is the *http.Request, required for logging.
+key is the key to lookup in the toml file.
+lang is the language.
+keyPrefix is an optional prefix to the key string.
+plural is the plural int required for toml file lookup.
+*/
+func Pluralise(req *http.Request, key, lang, keyPrefix string, plural int) string {
+	ctx := req.Context()
+	// Convert input to a string that can be used as a lookup in toml files
+	// String will be title case with given prefix e.g. PrefixInputString
+	log.Info(ctx, "converting input string", log.Data{
+		"input": key,
+	})
+	str := cases.Title(language.English).String(key)
+	str = strings.ReplaceAll(str, " ", "")
+	str = keyPrefix + str
+	// Localise will not return an error but will panic and return an empty string.
+	// The given input may not be stored in the toml files, so risk of panic is high.
+	// Therefore log panic and handle returned empty string in calling function
+	defer func() {
+		if err := recover(); err != nil {
+			log.Info(ctx, "recovered from panic", log.Data{
+				"lookup_not_found": str,
+			})
+		}
+	}()
+	log.Info(ctx, "performing toml lookup", log.Data{
+		"lookup": str,
+	})
+	return helper.Localise(str, lang, plural)
 }

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,9 +1,12 @@
 package helpers
 
 import (
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mocks"
+	"github.com/ONSdigital/dp-renderer/helper"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -61,5 +64,51 @@ func TestToBoolPtr(t *testing.T) {
 		So(ToBoolPtr(false), ShouldNotBeNil)
 		truePtr := func(b bool) *bool { return &b }(true)
 		So(ToBoolPtr(true), ShouldResemble, truePtr)
+	})
+}
+
+func TestPluralise(t *testing.T) {
+	helper.InitialiseLocalisationsHelper(mocks.MockAssetFunction)
+	req := httptest.NewRequest("GET", "http://localhost:20100", nil)
+
+	Convey("Given a valid key with lookup prefix", t, func() {
+		input := "Country"
+		expectedOutput := "Countries"
+		lookupPrefix := "AreaType"
+		sut := Pluralise(req, input, "en", lookupPrefix, 4)
+
+		Convey("Then pluralised value is returned", func() {
+			So(sut, ShouldEqual, expectedOutput)
+		})
+	})
+
+	Convey("Given a valid key without lookup prefix", t, func() {
+		input := "Test"
+		expectedOutput := "Tests"
+		sut := Pluralise(req, input, "en", "", 4)
+
+		Convey("Then pluralised value is returned", func() {
+			So(sut, ShouldEqual, expectedOutput)
+		})
+	})
+
+	Convey("Given a valid key without lookup prefix in Welsh", t, func() {
+		input := "Test"
+		expectedOutput := "Tests (cy)"
+		sut := Pluralise(req, input, "cy", "", 4)
+
+		Convey("Then pluralised value is returned", func() {
+			So(sut, ShouldEqual, expectedOutput)
+		})
+	})
+
+	Convey("Given an invalid key", t, func() {
+		input := "Blah blah"
+		expectedOutput := ""
+		sut := Pluralise(req, input, "", "", 1)
+
+		Convey("Then empty string is returned", func() {
+			So(sut, ShouldEqual, expectedOutput)
+		})
 	})
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -166,10 +166,10 @@ func TestUnitMapper(t *testing.T) {
 	})
 
 	Convey("test create selector maps correctly", t, func() {
-		m := CreateSelector(req, mdl, "dimensionName", lang, "12345")
+		m := CreateSelector(req, mdl, "dimension Name", lang, "12345")
 		So(m.BetaBannerEnabled, ShouldBeTrue)
 		So(m.Type, ShouldEqual, "filter-flex-selector")
-		So(m.Metadata.Title, ShouldEqual, "DimensionName")
+		So(m.Metadata.Title, ShouldEqual, "Dimension Name")
 		So(m.Language, ShouldEqual, lang)
 		So(m.Breadcrumb[0].URI, ShouldEqual, "/filters/12345/dimensions")
 		So(m.Breadcrumb[0].Title, ShouldEqual, "Back")
@@ -241,20 +241,29 @@ func TestGetCoverage(t *testing.T) {
 	Convey("Given a valid page", t, func() {
 		const lang = "en"
 		req := httptest.NewRequest("", "/", nil)
-		coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Geography Label")
 
-		Convey("it sets page metadata", func() {
-			So(coverage.BetaBannerEnabled, ShouldBeTrue)
-			So(coverage.Type, ShouldEqual, "filter-flex-coverage")
-			So(coverage.Language, ShouldEqual, lang)
+		Convey("When the parameters are valid", func() {
+			coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Country")
+			Convey("it sets page metadata", func() {
+				So(coverage.BetaBannerEnabled, ShouldBeTrue)
+				So(coverage.Type, ShouldEqual, "filter-flex-coverage")
+				So(coverage.Language, ShouldEqual, lang)
+			})
+
+			Convey("it sets the title to Coverage", func() {
+				So(coverage.Metadata.Title, ShouldEqual, "Coverage")
+			})
+
+			Convey("it sets the geography to countries", func() {
+				So(coverage.Geography, ShouldEqual, "countries")
+			})
 		})
 
-		Convey("it sets the title to Coverage", func() {
-			So(coverage.Metadata.Title, ShouldEqual, "Coverage")
-		})
-
-		Convey("it sets the geography to geography label", func() {
-			So(coverage.Geography, ShouldEqual, "geography label")
+		Convey("When an unknown geography parameter is given", func() {
+			coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Unknown geography")
+			Convey("Then it sets the geography to unknown geography", func() {
+				So(coverage.Geography, ShouldEqual, "unknown geography")
+			})
 		})
 	})
 }

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -5,11 +5,23 @@ import "strings"
 var cyLocale = []string{
 	"[Back]",
 	"one = \"Back\"",
+	"[AreaTypeCountry]",
+	"one = \"Country\"",
+	"other = \"Countries\"",
+	"[Test]",
+	"one = \"Test (cy)\"",
+	"other = \"Tests (cy)\"",
 }
 
 var enLocale = []string{
 	"[Back]",
 	"one = \"Back\"",
+	"[AreaTypeCountry]",
+	"one = \"Country\"",
+	"other = \"Countries\"",
+	"[Test]",
+	"one = \"Test\"",
+	"other = \"Tests\"",
 }
 
 // MockAssetFunction returns mocked toml []bytes


### PR DESCRIPTION
### What

Handle pluralisation lookups within app. The intention is the pluralisation is stored locally and not dependent on third party libraries or additional database dependencies. The `geogName` value is retrieved from the api and is returned in its singular form. The frontend presentation requires the plural to be displayed.

Parameter `geogName` is passed which helper func `Pluralise()` will convert into a lookup key to check in the toml file. 

Additional work that **resolves** trello ticket [5746 - Add coverage form data](https://trello.com/c/Ek3amhSL/5746-add-coverage-form-data)

#### Scenarios
**Lookup found** 
- Pluralised value returned

**Lookup fails**
- Error handling avoids a panic (panic is expected when `Localise()` fails)
- Log the error 
- Return the initial `geogName`

### How to review

- Sense check
- Spell/grammar check
- Tests pass

### Who can review

Frontend go dev
