### PR TITLE
Fix/find dimension with 'is_area_type=true'

### DIFF
--- a/handlers/get_coverage.go
+++ b/handlers/get_coverage.go
@@ -37,13 +37,12 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 			setStatusCode(req, w, err)
 			return
 		}
-		dim.IsAreaType = filterDimension.IsAreaType
-		filterDims.Items[i] = dim
+		filterDims.Items[i].IsAreaType = filterDimension.IsAreaType
 	}
 
 	// Only one dimension with `is_area_type=true'
 	sort.Search(len(filterDims.Items), func(i int) bool {
-		return *filterDims.Items[i].IsAreaType == true
+		return *filterDims.Items[i].IsAreaType
 	})
 
 	basePage := rc.NewBasePageModel()

--- a/handlers/get_coverage.go
+++ b/handlers/get_coverage.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"net/http"
+	"sort"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mapper"
 	"github.com/ONSdigital/dp-net/v2/handlers"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -20,14 +22,31 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 	vars := mux.Vars(req)
 	filterID := vars["filterID"]
 
-	geography, _, err := fc.GetDimension(ctx, accessToken, "", collectionID, filterID, "geography")
+	filterDims, _, err := fc.GetDimensions(ctx, accessToken, "", collectionID, filterID, &filter.QueryParams{Limit: 500})
 	if err != nil {
-		log.Error(ctx, "failed to get geography dimension", err, log.Data{"filter_id": filterID})
+		log.Error(ctx, "failed to get dimensions", err, log.Data{"filter_id": filterID})
 		setStatusCode(req, w, err)
 		return
 	}
 
+	for i, dim := range filterDims.Items {
+		// Needed to determine whether dimension is_area_type
+		filterDimension, _, err := fc.GetDimension(ctx, accessToken, "", collectionID, filterID, dim.Name)
+		if err != nil {
+			log.Error(ctx, "failed to get dimension", err, log.Data{"dimension_name": dim.Name})
+			setStatusCode(req, w, err)
+			return
+		}
+		dim.IsAreaType = filterDimension.IsAreaType
+		filterDims.Items[i] = dim
+	}
+
+	// Only one dimension with `is_area_type=true'
+	sort.Search(len(filterDims.Items), func(i int) bool {
+		return *filterDims.Items[i].IsAreaType == true
+	})
+
 	basePage := rc.NewBasePageModel()
-	m := mapper.CreateGetCoverage(req, basePage, lang, filterID, geography.Label)
+	m := mapper.CreateGetCoverage(req, basePage, lang, filterID, filterDims.Items[0].Label)
 	rc.BuildPage(w, m, "coverage")
 }

--- a/handlers/get_coverage_test.go
+++ b/handlers/get_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/helpers"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mocks"
 	"github.com/ONSdigital/dp-renderer/helper"
 	coreModel "github.com/ONSdigital/dp-renderer/model"
@@ -19,6 +20,18 @@ func TestGetCoverageHandler(t *testing.T) {
 	helper.InitialiseLocalisationsHelper(mocks.MockAssetFunction)
 	mockCtrl := gomock.NewController(t)
 	cfg := initialiseMockConfig()
+	mockFilterDims := filter.Dimensions{
+		Items: []filter.Dimension{
+			{
+				Name:       "Test",
+				IsAreaType: new(bool),
+			},
+			{
+				Name:       "Test 2",
+				IsAreaType: helpers.ToBoolPtr(true),
+			},
+		},
+	}
 
 	Convey("Get coverage", t, func() {
 		Convey("Given a valid request", func() {
@@ -27,11 +40,27 @@ func TestGetCoverageHandler(t *testing.T) {
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage", nil)
 
 				mockRend := NewMockRenderClient(mockCtrl)
-				mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
-				mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), "coverage")
+				mockRend.
+					EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
+				mockRend.
+					EXPECT().
+					BuildPage(gomock.Any(), gomock.Any(), "coverage")
 
 				mockFc := NewMockFilterClient(mockCtrl)
-				mockFc.EXPECT().GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(filter.Dimension{}, "", nil)
+				mockFc.
+					EXPECT().
+					GetDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(mockFilterDims, "", nil)
+				mockFc.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[0].Name).
+					Return(mockFilterDims.Items[0], "", nil)
+				mockFc.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[1].Name).
+					Return(mockFilterDims.Items[1], "", nil)
 
 				router := mux.NewRouter()
 				router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(mockRend, mockFc))
@@ -43,12 +72,38 @@ func TestGetCoverageHandler(t *testing.T) {
 			})
 		})
 
-		Convey("When the filter API responds with an error", func() {
+		Convey("When the GetDimensions API call responds with an error", func() {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage", nil)
 
 			mockFc := NewMockFilterClient(mockCtrl)
-			mockFc.EXPECT().GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(filter.Dimension{}, "", errors.New("sorry"))
+			mockFc.
+				EXPECT().
+				GetDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(filter.Dimensions{}, "", errors.New("sorry"))
+
+			router := mux.NewRouter()
+			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc))
+			router.ServeHTTP(w, req)
+
+			Convey("Then the status code should be 500", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
+		Convey("When the subsequent GetDimension API call responds with an error", func() {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage", nil)
+
+			mockFc := NewMockFilterClient(mockCtrl)
+			mockFc.
+				EXPECT().
+				GetDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockFilterDims, "", nil)
+			mockFc.
+				EXPECT().
+				GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[0].Name).
+				Return(filter.Dimension{}, "", errors.New("sorry"))
 
 			router := mux.NewRouter()
 			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc))


### PR DESCRIPTION
### What

Use of hardcoded name `geography` may not be reliable in returning geography dimension. Re-worked logic to iterate over all dimensions, check which has the `is_area_type=true` flag and return that.

### How to review

- Sense check
- Tests pass

### Who can review

!me
