### PR TITLE
Feature/perform area search

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -149,3 +149,13 @@ one = "Show all {{.arg0}} categories"
 [TruncateShowFewer]
 description = "Show less categories"
 one = "Show less categories"
+
+[SearchResults]
+description = "Results"
+one = "Result"
+other = "Results"
+
+[SearchNoResults]
+description = "No results found"
+one = "No result found"
+other = "No results found"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -149,3 +149,13 @@ one = "Show all {{.arg0}} categories"
 [TruncateShowFewer]
 description = "Show less categories"
 one = "Show less categories"
+
+[SearchResults]
+description = "Results"
+one = "Result"
+other = "Results"
+
+[SearchNoResults]
+description = "No results found"
+one = "No result found"
+other = "No results found"

--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -2,40 +2,28 @@
     <div class="ons-grid ons-u-ml-no">
         {{ template "partials/breadcrumb" . }}
         <h1 class="ons-u-fs-xxxl ons-u-mt-s ons-u-fw-b">{{ .Page.Metadata.Title }}</h1>
-        <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
+        <div class="ons-grid__col ons-col-7@m ons-u-pl-no">
             <div class="ons-page__main ons-u-mt-l">
-                <form method="get">
-                    <fieldset class="ons-fieldset">
-                        <legend class="ons-fieldset__legend">{{- localise "CoverageLegend" .Language 1 -}}</legend>
-                        <div class="ons-radios__items">
-                            <span class="ons-radios__item ons-radios__item--no-border">
-                                <span class="ons-radio ons-radio--no-border">
-                                    <input type="radio" 
-                                        id="coverage-default" 
-                                        class="ons-radio__input ons-js-radio" 
-                                        value="coverage-default"
-                                        name="coverage" 
-                                        checked>
-                                    <label class=" ons-radio__label" for="coverage-default">{{- localise "CoverageDefault" .Language 1 .Geography -}}</label>
-                                </span>
+                <fieldset class="ons-fieldset">
+                    <legend class="ons-fieldset__legend">{{- localise "CoverageLegend" .Language 1 -}}</legend>
+                    <div class="ons-radios__items">
+                        <span class="ons-radios__item ons-radios__item--no-border">
+                            <span class="ons-radio ons-radio--no-border">
+                                <input type="radio" id="coverage-default" class="ons-radio__input ons-js-radio" value="coverage-default" name="coverage" {{ if eq .IsSearch false }} checked {{ end }}>
+                                <label class=" ons-radio__label" for="coverage-default">{{- localise "CoverageDefault" .Language 1 .Geography -}}</label>
                             </span>
-                            <br>
-                            <span class="ons-radios__item ons-radios__item--no-border ons-u-fw">
-                                <span class="ons-radio ons-radio--no-border">
-                                    <input 
-                                        type="radio" 
-                                        id="coverage-search" 
-                                        class="ons-radio__input ons-js-radio ons-js-other" 
-                                        value="coverage-search" 
-                                        name="coverage" 
-                                        aria-controls="other-radio-other-wrap" 
-                                        aria-haspopup="true">
-                                    <label class="ons-radio__label" for="coverage-search">{{- localise "CoverageSearch" .Language 1 .Geography -}}</label>
-                                    <span class="ons-radio__other" id="other-radio-other-wrap">
+                        </span>
+                        <br>
+                        <div class="ons-radios__item ons-radios__item--no-border ons-u-fw">
+                            <div class="ons-radio ons-radio--no-border">
+                                <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="coverage-search" name="coverage" aria-controls="other-radio-other-wrap" aria-haspopup="true" {{ if .IsSearch }} checked {{ end }}>
+                                <label class="ons-radio__label" for="coverage-search">{{- localise "CoverageSearch" .Language 1 .Geography -}}</label>
+                                <div class="ons-radio__other ons-u-pb-no" id="other-radio-other-wrap">
+                                    <form>
                                         <span class="ons-field">
                                             <label class="ons-label ons-u-pb-xs" for="search-field">{{- localise "CoverageSearchLabel" .Language 1 -}}</label>
                                             <span class="ons-grid--flex ons-search">
-                                                <input type="search" id="search-field" class="ons-input ons-search__input" />
+                                                <input type="search" id="search-field" name="q" value="{{- .Search -}}" class="ons-input ons-search__input"/>
                                                 <button type="submit" class="ons-btn ons-btn--secondary ons-search__btn ons-u-mt-xs@xxs@s ons-btn--small">
                                                     <span class="ons-btn__inner">
                                                         {{ template "icons/search" }}
@@ -44,11 +32,26 @@
                                                 </button>
                                             </span>
                                         </span>
-                                    </span>
-                                </span>
-                            </span>
+                                    </form>
+                                    {{ if .IsSearch }}
+                                        {{ $length := len .SearchResults }}
+                                        {{ if gt $length 0  }}
+                                            <div class="ons-u-mt-xs ons-u-fw-b">{{- localise "SearchResults" .Language 4 -}}</div>
+                                            <ul>
+                                                {{ range .SearchResults }}
+                                                    <li>{{ .Label }}</li>
+                                                {{ end }}
+                                            </ul>
+                                        {{ else }}
+                                            <div class="ons-u-mt-s">{{- localise "SearchNoResults" .Language 4 -}}</div>
+                                        {{ end }}
+                                    {{ end }}
+                                </div>
+                            </div>
                         </div>
-                    </fieldset>
+                    </div>
+                </fieldset>
+                <form>
                     <button type="submit" class="ons-btn ons-u-mt-xl ons-u-mb-s">
                         <span class="ons-btn__inner">{{- localise "Continue" .Language 1 -}}</span>
                     </button>

--- a/handlers/get_coverage.go
+++ b/handlers/get_coverage.go
@@ -2,24 +2,43 @@ package handlers
 
 import (
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mapper"
 	"github.com/ONSdigital/dp-net/v2/handlers"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 )
 
-func GetCoverage(rc RenderClient, fc FilterClient) http.HandlerFunc {
+// GetCoverage handler
+func GetCoverage(rc RenderClient, fc FilterClient, pc PopulationClient) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
-		getCoverage(w, req, rc, fc, lang, accessToken, collectionID)
+		getCoverage(w, req, rc, fc, pc, lang, accessToken, collectionID)
 	})
 }
 
-func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc FilterClient, lang, accessToken, collectionID string) {
+func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc FilterClient, pc PopulationClient, lang, accessToken, collectionID string) {
 	ctx := req.Context()
 	vars := mux.Vars(req)
 	filterID := vars["filterID"]
+	q := req.URL.Query().Get("q")
+	isSearch := strings.Contains(req.URL.RawQuery, "q=")
+
+	filterJob, err := fc.GetFilter(ctx, filter.GetFilterInput{
+		FilterID: filterID,
+		AuthHeaders: filter.AuthHeaders{
+			UserAuthToken: accessToken,
+			CollectionID:  collectionID,
+		},
+	})
+	if err != nil {
+		log.Error(ctx, "failed to get filter", err, log.Data{"filter_id": filterID})
+		setStatusCode(req, w, err)
+		return
+	}
 
 	filterDims, _, err := fc.GetDimensions(ctx, accessToken, "", collectionID, filterID, &filter.QueryParams{Limit: 500})
 	if err != nil {
@@ -28,7 +47,7 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 		return
 	}
 
-	var geogLabel string
+	var geogLabel, geogID string
 	for _, dim := range filterDims.Items {
 		// Needed to determine whether dimension is_area_type
 		// Only one dimension will be is_area_type=true
@@ -40,10 +59,26 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 		}
 		if *filterDimension.IsAreaType {
 			geogLabel = filterDimension.Label
+			geogID = filterDimension.ID
+		}
+	}
+
+	areas := population.GetAreasResponse{}
+	if isSearch && q != "" {
+		areas, err = pc.GetAreas(ctx, population.GetAreasInput{
+			UserAuthToken: accessToken,
+			DatasetID:     filterJob.PopulationType,
+			AreaTypeID:    geogID,
+			Text:          url.QueryEscape(strings.TrimSpace(q)),
+		})
+		if err != nil {
+			log.Error(ctx, "failed to get areas", err, log.Data{"area": geogID})
+			setStatusCode(req, w, err)
+			return
 		}
 	}
 
 	basePage := rc.NewBasePageModel()
-	m := mapper.CreateGetCoverage(req, basePage, lang, filterID, geogLabel)
+	m := mapper.CreateGetCoverage(req, basePage, lang, filterID, geogLabel, q, areas, isSearch)
 	rc.BuildPage(w, m, "coverage")
 }

--- a/handlers/get_coverage_test.go
+++ b/handlers/get_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/helpers"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mocks"
 	"github.com/ONSdigital/dp-renderer/helper"
@@ -61,9 +62,59 @@ func TestGetCoverageHandler(t *testing.T) {
 					EXPECT().
 					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[1].Name).
 					Return(mockFilterDims.Items[1], "", nil)
+				mockFc.EXPECT().
+					GetFilter(gomock.Any(), gomock.Any()).
+					Return(&filter.GetFilterResponse{}, nil)
+
+				mockPc := NewMockPopulationClient(mockCtrl)
 
 				router := mux.NewRouter()
-				router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(mockRend, mockFc))
+				router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(mockRend, mockFc, mockPc))
+				router.ServeHTTP(w, req)
+
+				Convey("And the status code should be 200", func() {
+					So(w.Code, ShouldEqual, http.StatusOK)
+				})
+			})
+
+			Convey("When the user performs a search", func() {
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage?q=name", nil)
+
+				mockRend := NewMockRenderClient(mockCtrl)
+				mockRend.
+					EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
+				mockRend.
+					EXPECT().
+					BuildPage(gomock.Any(), gomock.Any(), "coverage")
+
+				mockFc := NewMockFilterClient(mockCtrl)
+				mockFc.
+					EXPECT().
+					GetDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(mockFilterDims, "", nil)
+				mockFc.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[0].Name).
+					Return(mockFilterDims.Items[0], "", nil)
+				mockFc.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[1].Name).
+					Return(mockFilterDims.Items[1], "", nil)
+				mockFc.EXPECT().
+					GetFilter(gomock.Any(), gomock.Any()).
+					Return(&filter.GetFilterResponse{}, nil)
+
+				mockPc := NewMockPopulationClient(mockCtrl)
+				mockPc.
+					EXPECT().
+					GetAreas(gomock.Any(), gomock.Any()).
+					Return(population.GetAreasResponse{}, nil)
+
+				router := mux.NewRouter()
+				router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(mockRend, mockFc, mockPc))
 				router.ServeHTTP(w, req)
 
 				Convey("And the status code should be 200", func() {
@@ -72,18 +123,39 @@ func TestGetCoverageHandler(t *testing.T) {
 			})
 		})
 
+		Convey("When the GetFilter API call responds with an error", func() {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage", nil)
+
+			mockFc := NewMockFilterClient(mockCtrl)
+			mockFc.EXPECT().
+				GetFilter(gomock.Any(), gomock.Any()).
+				Return(&filter.GetFilterResponse{}, errors.New("sorry"))
+
+			router := mux.NewRouter()
+			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, NewMockPopulationClient(mockCtrl)))
+			router.ServeHTTP(w, req)
+
+			Convey("Then the status code should be 500", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
 		Convey("When the GetDimensions API call responds with an error", func() {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage", nil)
 
 			mockFc := NewMockFilterClient(mockCtrl)
+			mockFc.EXPECT().
+				GetFilter(gomock.Any(), gomock.Any()).
+				Return(&filter.GetFilterResponse{}, nil)
 			mockFc.
 				EXPECT().
 				GetDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(filter.Dimensions{}, "", errors.New("sorry"))
 
 			router := mux.NewRouter()
-			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc))
+			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, NewMockPopulationClient(mockCtrl)))
 			router.ServeHTTP(w, req)
 
 			Convey("Then the status code should be 500", func() {
@@ -96,6 +168,9 @@ func TestGetCoverageHandler(t *testing.T) {
 			req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage", nil)
 
 			mockFc := NewMockFilterClient(mockCtrl)
+			mockFc.EXPECT().
+				GetFilter(gomock.Any(), gomock.Any()).
+				Return(&filter.GetFilterResponse{}, nil)
 			mockFc.
 				EXPECT().
 				GetDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -106,7 +181,43 @@ func TestGetCoverageHandler(t *testing.T) {
 				Return(filter.Dimension{}, "", errors.New("sorry"))
 
 			router := mux.NewRouter()
-			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc))
+			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, NewMockPopulationClient(mockCtrl)))
+			router.ServeHTTP(w, req)
+
+			Convey("Then the status code should be 500", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
+		Convey("When the GetAreas API call responds with an error", func() {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage?q=test", nil)
+
+			mockFc := NewMockFilterClient(mockCtrl)
+			mockFc.
+				EXPECT().
+				GetDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockFilterDims, "", nil)
+			mockFc.
+				EXPECT().
+				GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[0].Name).
+				Return(mockFilterDims.Items[0], "", nil)
+			mockFc.
+				EXPECT().
+				GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[1].Name).
+				Return(mockFilterDims.Items[1], "", nil)
+			mockFc.EXPECT().
+				GetFilter(gomock.Any(), gomock.Any()).
+				Return(&filter.GetFilterResponse{}, nil)
+
+			mockPc := NewMockPopulationClient(mockCtrl)
+			mockPc.
+				EXPECT().
+				GetAreas(gomock.Any(), gomock.Any()).
+				Return(population.GetAreasResponse{}, errors.New("sorry"))
+
+			router := mux.NewRouter()
+			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, mockPc))
 			router.ServeHTTP(w, req)
 
 			Convey("Then the status code should be 500", func() {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -169,7 +169,7 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, fi
 }
 
 // CreateGetCoverage maps data to the coverage model
-func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID, geogName string) model.Coverage {
+func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID, geogName, query string, areas population.GetAreasResponse, isSearch bool) model.Coverage {
 	p := model.Coverage{
 		Page: basePage,
 	}
@@ -190,6 +190,17 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 	}
 
 	p.Geography = strings.ToLower(geography)
+	p.IsSearch = isSearch
+	p.Search = query
+
+	var results []model.SearchResult
+	for _, area := range areas.Areas {
+		results = append(results, model.SearchResult{
+			Label: area.Label,
+			ID:    area.ID,
+		})
+	}
+	p.SearchResults = results
 
 	return p
 }

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -7,5 +7,14 @@ import (
 // Coverage represents the data to display the coverage page
 type Coverage struct {
 	coreModel.Page
-	Geography string `json:"geography"`
+	Geography     string         `json:"geography"`
+	IsSearch      bool           `json:"is_search"`
+	Search        string         `json:"search"`
+	SearchResults []SearchResult `json:"search_results"`
+}
+
+// SearchResult represents the data required to display a search result
+type SearchResult struct {
+	Label string `json:"label"`
+	ID    string `json:"id"`
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -36,5 +36,5 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions").Methods("GET").HandlerFunc(handlers.FilterFlexOverview(c.Render, c.Filter, c.Dataset, c.Population))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(handlers.DimensionsSelector(c.Render, c.Filter, c.Population))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("POST").HandlerFunc(handlers.ChangeDimension(c.Filter))
-	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/geography/coverage").Methods("GET").HandlerFunc(handlers.GetCoverage(c.Render, c.Filter))
+	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/geography/coverage").Methods("GET").HandlerFunc(handlers.GetCoverage(c.Render, c.Filter, c.Population))
 }


### PR DESCRIPTION
### What

Updated `get_coverage` handler to perform area search by name using population client

✅  **Resolves** trello ticket [5765 - Update coverage handler to perform search](https://trello.com/c/Q5Tif9ab/5765-update-coverage-handler-to-perform-search)

### How to review

- Sense check
- Tests pass
- Review video
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. 
  - Create a flexible dataset
  - Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-default/editions/2021/versions/1)
  - Click 'change' on 'coverage'
  - Search for a geography by name
  - **OR** call me 🤙 and I'll show you 

**Forthcoming development** 
- List of results will look as per [design](https://www.figma.com/proto/JLlYEPtSK2NxrBTVkxLCJB/ONS-DP-GetDataUI?page-id=1779%3A136224&node-id=1779%3A136225&viewport=501%2C48%2C0.25&scaling=min-zoom&starting-point-node-id=1779%3A136225)
- Select an area name 
- Save changes
- Concurrent API calls 🤞 

#### Video

https://user-images.githubusercontent.com/19624419/178008976-3c5f0074-7566-4b7d-8895-e9d9298f5ef0.mov

### Who can review

Frontend go dev
