### PR TITLE
Feature/implement search design

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -159,3 +159,16 @@ other = "Results"
 description = "No results found"
 one = "No result found"
 other = "No results found"
+
+[SearchResultsAdd]
+description = "Add"
+one = "Add"
+
+[SearchResultsRemove]
+description = "Remove"
+one = "Remove"
+
+[AreasAddedTitle]
+description = "Areas added"
+one = "Area added"
+other = "Areas added"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -159,3 +159,16 @@ other = "Results"
 description = "No results found"
 one = "No result found"
 other = "No results found"
+
+[SearchResultsAdd]
+description = "Add"
+one = "Add"
+
+[SearchResultsRemove]
+description = "Remove"
+one = "Remove"
+
+[AreasAddedTitle]
+description = "Areas added"
+one = "Area added"
+other = "Areas added"

--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -9,17 +9,17 @@
                     <div class="ons-radios__items">
                         <span class="ons-radios__item ons-radios__item--no-border">
                             <span class="ons-radio ons-radio--no-border">
-                                <input type="radio" id="coverage-default" class="ons-radio__input ons-js-radio" value="coverage-default" name="coverage" {{ if eq .IsSearch false }} checked {{ end }}>
+                                <input type="radio" id="coverage-default" class="ons-radio__input ons-js-radio" value="coverage-default" name="coverage" {{ if eq .IsSearch false }} checked="checked" {{ end }}>
                                 <label class=" ons-radio__label" for="coverage-default">{{- localise "CoverageDefault" .Language 1 .Geography -}}</label>
                             </span>
                         </span>
                         <br>
                         <div class="ons-radios__item ons-radios__item--no-border ons-u-fw">
                             <div class="ons-radio ons-radio--no-border">
-                                <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="coverage-search" name="coverage" aria-controls="other-radio-other-wrap" aria-haspopup="true" {{ if .IsSearch }} checked {{ end }}>
+                                <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="coverage-search" name="coverage" {{ if .IsSearch }} checked="checked" {{ end }}>
                                 <label class="ons-radio__label" for="coverage-search">{{- localise "CoverageSearch" .Language 1 .Geography -}}</label>
                                 <div class="ons-radio__other ons-u-pb-no" id="other-radio-other-wrap">
-                                    <form>
+                                    <form class="ons-u-pb-xs">
                                         <span class="ons-field">
                                             <label class="ons-label ons-u-pb-xs" for="search-field">{{- localise "CoverageSearchLabel" .Language 1 -}}</label>
                                             <span class="ons-grid--flex ons-search">
@@ -34,19 +34,57 @@
                                         </span>
                                     </form>
                                     {{ if .IsSearch }}
-                                        {{ $length := len .SearchResults }}
-                                        {{ if gt $length 0  }}
-                                            <div class="ons-u-mt-xs ons-u-fw-b">{{- localise "SearchResults" .Language 4 -}}</div>
-                                            <ul>
+                                        {{ if .SearchResults }}
+                                            <div class="ons-u-mt-xs ons-u-mb-xs ons-u-fw-b">{{- localise "SearchResults" .Language 4 -}}</div>
+                                            <ul class="ons-list--bare ons-u-mb-no coverage-search">
                                                 {{ range .SearchResults }}
-                                                    <li>{{ .Label }}</li>
+                                                    <li class="ons-u-bt ons-list__item coverage-search__results">
+                                                        {{- .Label -}}
+                                                        <button type="button" class="ons-btn ons-btn--secondary ons-btn--small">
+                                                            <span class="ons-btn__inner">
+                                                                {{ if .IsSelected }}
+                                                                    <span class="ons-btn__text">{{- localise "SearchResultsRemove" $.Language 1 -}}</span>
+                                                                {{ else }}
+                                                                    <span class="ons-btn__text">{{- localise "SearchResultsAdd" $.Language 1 -}}</span>
+                                                                {{ end }}
+                                                                <span class="ons-u-vh">{{ .Label -}}</span>
+                                                            </span>
+                                                        </button>
+                                                    </li>
                                                 {{ end }}
                                             </ul>
                                         {{ else }}
-                                            <div class="ons-u-mt-s">{{- localise "SearchNoResults" .Language 4 -}}</div>
+                                            <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
                                         {{ end }}
+                                        {{ if .AreasAdded }}
+                                            {{ $len := len .AreasAdded }}
+                                            <div class="ons-u-fw-b ons-u-pt-s ons-u-mb-xs">
+                                                {{ if eq $len 1 }}
+                                                    {{- localise "AreasAddedTitle" .Language 1 -}}
+                                                {{ else }}
+                                                    {{- localise "AreasAddedTitle" .Language 4 -}}
+                                                {{ end }}
+                                            </div>
+                                            <form class="ons-u-pb-xs">
+                                                <ul class="ons-list--bare ons-u-mb-no coverage-selection">
+                                                    {{ range .AreasAdded }}
+                                                        <li class="ons-u-mb-no coverage-selection__selected">
+                                                            <button type="button" class="ons-btn ons-btn--secondary">
+                                                                <span class="ons-btn__inner">
+                                                                    <span class="ons-u-vh">{{- localise "SearchResultsRemove" $.Language 1 -}}</span>
+                                                                    <span class="ons-btn__text">{{ . }}</span>
+                                                                    <span class="ons-u-pl-xs">
+                                                                        {{ template "icons/cross" . }}
+                                                                    </span>
+                                                                </span>
+                                                            </button>
+                                                        </li>
+                                                    {{ end }}
+                                                </ul>
+                                            </form>
+                                        </div>
                                     {{ end }}
-                                </div>
+                                {{ end }}
                             </div>
                         </div>
                     </div>

--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -82,9 +82,9 @@
                                                     {{ end }}
                                                 </ul>
                                             </form>
-                                        </div>
+                                        {{ end }}
                                     {{ end }}
-                                {{ end }}
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/7129615"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/80d766d"
 	}
 
 	return cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
 				So(cfg.BindAddr, ShouldEqual, "localhost:20100")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/7129615")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/80d766d")
 				So(cfg.SupportedLanguages, ShouldResemble, []string{"en", "cy"})
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.4.0-beta
 	github.com/ONSdigital/dp-net/v2 v2.5.0-beta
-	github.com/ONSdigital/dp-renderer v1.40.0-beta
+	github.com/ONSdigital/dp-renderer v1.39.0
 	github.com/ONSdigital/log.go/v2 v2.3.0-beta
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
@@ -6,8 +7,6 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.150.1-beta h1:0cGI5E23r8ffEZDezAH92gV98csYrHW0SBbZyXg9d2o=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.150.1-beta/go.mod h1:PW75Y2J2edrAspaB6MiT5rhwS2ga1GlMuZRyf76VDRo=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.156.0 h1:gXdIommFlsRObENVdNqU/0Oy40W80msi0FntDBlNz38=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.156.0/go.mod h1:hT71K0YuLeXjV1o/jKVdp1407kQuTj0x9mIIebaBwfg=
 github.com/ONSdigital/dp-cookies v0.3.3 h1:KXX4swf+OnljIYbsTYICIBjuRJoxQukGWKBTvBaISlA=
@@ -16,8 +15,8 @@ github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=
 github.com/ONSdigital/dp-healthcheck v1.4.0-beta h1:rnFF65/1gaswgOzs4zMjoR7yD4vF+8aqoOQ9SRS1DB0=
 github.com/ONSdigital/dp-healthcheck v1.4.0-beta/go.mod h1:rIy35w7Bqos8+iSMISsiYG4GsDUH7vgKgtjAQCP5cVo=
+github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
-github.com/ONSdigital/dp-mocking v0.9.0-beta h1:a1tpJ39sh76JQcM9kHqJMKgEnbIJ7pTc0HSXhhymRJ4=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=
@@ -28,6 +27,8 @@ github.com/ONSdigital/dp-net v1.4.1 h1:hfhtQ2l7pGtC2nBze7YtFzvkVEMCYprHgojNYVPL1
 github.com/ONSdigital/dp-net v1.4.1/go.mod h1:VK8dah+G0TeVO/Os/w17Rk4WM6hIGmdUXrm8fBWyC+g=
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta h1:be/sM3nEXy5ejU/bvpO/KigUXcfED9o6c+zAh/V2K74=
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta/go.mod h1:QJK9K2N8qwjMS5nZEzxSVALxJ/72KHAFDyFLj/mdLtw=
+github.com/ONSdigital/dp-renderer v1.39.0 h1:wmtxBuxkoKrEjU980pT+5qbeFGJCLgszjHaKv2Q4UQI=
+github.com/ONSdigital/dp-renderer v1.39.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
 github.com/ONSdigital/dp-renderer v1.40.0-beta h1:l88qGRQzrw5zeFE8ir8CIKDaohIUK5UryDB5BLf3VDE=
 github.com/ONSdigital/dp-renderer v1.40.0-beta/go.mod h1:zu3sWE3Q4OQQq1+2txtU4NdhroI7zUeFZg82HMA/45Y=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
@@ -35,6 +36,7 @@ github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHB
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
+github.com/ONSdigital/log.go v1.1.0 h1:XFE8U5lPeiXyujgUtbh+pKCotiICeIGFEAauNk9c24A=
 github.com/ONSdigital/log.go v1.1.0/go.mod h1:0hOVuYR3bDUI30VRo48d5KHfJIoe+spuPXqgt6UF78o=
 github.com/ONSdigital/log.go/v2 v2.0.0/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
@@ -44,15 +46,18 @@ github.com/ONSdigital/log.go/v2 v2.3.0-beta/go.mod h1:rfe7OO0rXInVz7gLWmuPlpHilN
 github.com/aws/aws-sdk-go v1.38.15/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.44.43 h1:gILXnQAOkfAV9dhdXOUlnVTGM3AiOQFqwQmJJ9R7rUE=
 github.com/aws/aws-sdk-go v1.44.43/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b h1:6+ZFm0flnudZzdSE0JxlhR2hKnGPcNB35BjQf4RYQDY=
 github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
@@ -66,6 +71,7 @@ github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25d
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gosimple/slug v1.9.0/go.mod h1:AMZ+sOVe65uByN3kgEyf9WEBKBCSS+dJjMX9x4vDJbg=
 github.com/gosimple/slug v1.12.0 h1:xzuhj7G7cGtd34NXnW/yF0l+AGNfWqwgh/IXgFy7dnc=
 github.com/gosimple/slug v1.12.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
 github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
@@ -76,6 +82,7 @@ github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfk
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -98,11 +105,14 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/nicksnyder/go-i18n/v2 v2.1.2/go.mod h1:d++QJC9ZVf7pa48qrsRWhMJ5pSHIPmS3OLqK1niyLxs=
 github.com/nicksnyder/go-i18n/v2 v2.2.0 h1:MNXbyPvd141JJqlU6gJKrczThxJy+kdCNivxZpBQFkw=
 github.com/nicksnyder/go-i18n/v2 v2.2.0/go.mod h1:4OtLfzqyAxsscyCb//3gfqSvBc81gImX91LrZzczN1o=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be/go.mod h1:MIDFMn7db1kT65GmV94GzpX9Qdi7N/pQlwb+AN8wh+Q=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -114,6 +124,8 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
+github.com/unrolled/render v1.4.0/go.mod h1:cK4RSTTVdND5j9EYEc0LAMOvdG11JeiKjyjfyZRvV2w=
 github.com/unrolled/render v1.5.0 h1:uNTHMvVoI9pyyXfgoDHHycIqFONNY2p4eQR9ty+NsxM=
 github.com/unrolled/render v1.5.0/go.mod h1:eLTosBkQqEPEk7pRfkCRApXd++lm++nCsVlFOHpeedw=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -139,6 +151,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -149,6 +162,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -178,3 +192,4 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -195,9 +195,17 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 
 	var results []model.SearchResult
 	for _, area := range areas.Areas {
+		var isSelected bool
+		for _, added := range p.AreasAdded {
+			if strings.EqualFold(added, area.Label) {
+				isSelected = true
+			}
+		}
+
 		results = append(results, model.SearchResult{
-			Label: area.Label,
-			ID:    area.ID,
+			Label:      area.Label,
+			ID:         area.ID,
+			IsSelected: isSelected,
 		})
 	}
 	p.SearchResults = results

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -199,6 +199,7 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 		for _, added := range p.AreasAdded {
 			if strings.EqualFold(added, area.Label) {
 				isSelected = true
+				break
 			}
 		}
 

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -11,10 +11,12 @@ type Coverage struct {
 	IsSearch      bool           `json:"is_search"`
 	Search        string         `json:"search"`
 	SearchResults []SearchResult `json:"search_results"`
+	AreasAdded    []string       `json:"areas_added"`
 }
 
 // SearchResult represents the data required to display a search result
 type SearchResult struct {
-	Label string `json:"label"`
-	ID    string `json:"id"`
+	Label      string `json:"label"`
+	ID         string `json:"id"`
+	IsSelected bool   `json:"is_selected"`
 }


### PR DESCRIPTION
### What

- Styling for coverage pages

✅  **Resolves** trello ticket [5766  - Display results from search GET](https://trello.com/c/jMn37r46/5766-display-results-from-search-get) 

### How to review

- Sense check
- Image check
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. 
  - Create a flexible dataset
  - Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-default/editions/2021/versions/1)
  - Click 'change' on 'coverage'
  - Search for a geography by name
  - To "fake" displaying areas added, in `mapper.go` on line `195` add something like `p.AreasAdded = []string{"liverpool", "Ealing"}`
  - **OR** call me 🤙 and I'll show you 

**Note** the add/remove buttons do not do anything, that functionality is coming soon!

<img width="633" alt="image" src="https://user-images.githubusercontent.com/19624419/178939574-46ed0ab6-522b-47c1-92fe-14af14b8a05e.png">

### Who can review

Frontend go dev
