### PR TITLE
Feature/adding post selected option functionality

### DIFF
--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -9,14 +9,14 @@
                     <div class="ons-radios__items">
                         <span class="ons-radios__item ons-radios__item--no-border">
                             <span class="ons-radio ons-radio--no-border">
-                                <input type="radio" id="coverage-default" class="ons-radio__input ons-js-radio" value="coverage-default" name="coverage" {{ if eq .IsSearch false }} checked="checked" {{ end }}>
+                                <input type="radio" id="coverage-default" class="ons-radio__input ons-js-radio" value="coverage-default" name="coverage" {{ if eq .DisplaySearch false }} checked="checked" {{ end }}>
                                 <label class=" ons-radio__label" for="coverage-default">{{- localise "CoverageDefault" .Language 1 .Geography -}}</label>
                             </span>
                         </span>
                         <br>
                         <div class="ons-radios__item ons-radios__item--no-border ons-u-fw">
                             <div class="ons-radio ons-radio--no-border">
-                                <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="coverage-search" name="coverage" {{ if .IsSearch }} checked="checked" {{ end }}>
+                                <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="coverage-search" name="coverage" {{ if .DisplaySearch }} checked="checked" {{ end }}>
                                 <label class="ons-radio__label" for="coverage-search">{{- localise "CoverageSearch" .Language 1 .Geography -}}</label>
                                 <div class="ons-radio__other ons-u-pb-no" id="other-radio-other-wrap">
                                     <form class="ons-u-pb-xs">
@@ -33,31 +33,35 @@
                                             </span>
                                         </span>
                                     </form>
-                                    {{ if .IsSearch }}
+                                    {{ if .DisplaySearch }}
                                         {{ if .SearchResults }}
                                             <div class="ons-u-mt-xs ons-u-mb-xs ons-u-fw-b">{{- localise "SearchResults" .Language 4 -}}</div>
-                                            <ul class="ons-list--bare ons-u-mb-no coverage-search">
-                                                {{ range .SearchResults }}
-                                                    <li class="ons-u-bt ons-list__item coverage-search__results">
-                                                        {{- .Label -}}
-                                                        <button type="button" class="ons-btn ons-btn--secondary ons-btn--small">
-                                                            <span class="ons-btn__inner">
-                                                                {{ if .IsSelected }}
-                                                                    <span class="ons-btn__text">{{- localise "SearchResultsRemove" $.Language 1 -}}</span>
-                                                                {{ else }}
-                                                                    <span class="ons-btn__text">{{- localise "SearchResultsAdd" $.Language 1 -}}</span>
-                                                                {{ end }}
-                                                                <span class="ons-u-vh">{{ .Label -}}</span>
-                                                            </span>
-                                                        </button>
-                                                    </li>
-                                                {{ end }}
-                                            </ul>
-                                        {{ else }}
+                                            <form method="post">
+                                                <input type="hidden" name="dimension" value="{{- .Dimension -}}">
+                                                <ul class="ons-list--bare ons-u-mb-no coverage-search">
+                                                    {{ range .SearchResults }}
+                                                        <li class="ons-u-bt ons-list__item coverage-search__results">
+                                                            {{- .Label -}}
+                                                            <button type="submit" name="option" value="{{- .ID -}}" class="ons-btn ons-btn--secondary ons-btn--small">
+                                                                <span class="ons-btn__inner">
+                                                                    {{ if .IsSelected }}
+                                                                        <span class="ons-btn__text">{{- localise "SearchResultsRemove" $.Language 1 -}}</span>
+                                                                    {{ else }}
+                                                                        <span class="ons-btn__text">{{- localise "SearchResultsAdd" $.Language 1 -}}</span>
+                                                                    {{ end }}
+                                                                    <span class="ons-u-vh">{{ .Label -}}</span>
+                                                                </span>
+                                                            </button>
+                                                        </li>
+                                                    {{ end }}
+                                                </ul>
+                                            </form>
+                                        {{ end }}
+                                        {{ if .HasNoResults }}
                                             <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
                                         {{ end }}
-                                        {{ if .AreasAdded }}
-                                            {{ $len := len .AreasAdded }}
+                                        {{ if .Options }}
+                                            {{ $len := len .Options }}
                                             <div class="ons-u-fw-b ons-u-pt-s ons-u-mb-xs">
                                                 {{ if eq $len 1 }}
                                                     {{- localise "AreasAddedTitle" .Language 1 -}}
@@ -67,12 +71,12 @@
                                             </div>
                                             <form class="ons-u-pb-xs">
                                                 <ul class="ons-list--bare ons-u-mb-no coverage-selection">
-                                                    {{ range .AreasAdded }}
+                                                    {{ range .Options }}
                                                         <li class="ons-u-mb-no coverage-selection__selected">
                                                             <button type="button" class="ons-btn ons-btn--secondary">
                                                                 <span class="ons-btn__inner">
                                                                     <span class="ons-u-vh">{{- localise "SearchResultsRemove" $.Language 1 -}}</span>
-                                                                    <span class="ons-btn__text">{{ . }}</span>
+                                                                    <span class="ons-btn__text">{{ .Label }}</span>
                                                                     <span class="ons-u-pl-xs">
                                                                         {{ template "icons/cross" . }}
                                                                     </span>

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -33,6 +33,8 @@ type FilterClient interface {
 	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q *filter.QueryParams) (dims filter.Dimensions, eTag string, err error)
 	UpdateDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch string, dimension filter.Dimension) (dim filter.Dimension, eTag string, err error)
 	SubmitFilter(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, ifMatch string, sfr filter.SubmitFilterRequest) (resp *filter.SubmitFilterResponse, eTag string, err error)
+	AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (eTag string, err error)
+	GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q *filter.QueryParams) (opts filter.DimensionOptions, eTag string, err error)
 }
 
 // DatasetClient is an interface with methods required for a dataset client

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -139,6 +139,21 @@ func (m *MockFilterClient) EXPECT() *MockFilterClientMockRecorder {
 	return m.recorder
 }
 
+// AddDimensionValue mocks base method.
+func (m *MockFilterClient) AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddDimensionValue", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddDimensionValue indicates an expected call of AddDimensionValue.
+func (mr *MockFilterClientMockRecorder) AddDimensionValue(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDimensionValue", reflect.TypeOf((*MockFilterClient)(nil).AddDimensionValue), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
+}
+
 // GetDimension mocks base method.
 func (m *MockFilterClient) GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (filter.Dimension, string, error) {
 	m.ctrl.T.Helper()
@@ -153,6 +168,22 @@ func (m *MockFilterClient) GetDimension(ctx context.Context, userAuthToken, serv
 func (mr *MockFilterClientMockRecorder) GetDimension(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimension", reflect.TypeOf((*MockFilterClient)(nil).GetDimension), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
+}
+
+// GetDimensionOptions mocks base method.
+func (m *MockFilterClient) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q *filter.QueryParams) (filter.DimensionOptions, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDimensionOptions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q)
+	ret0, _ := ret[0].(filter.DimensionOptions)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDimensionOptions indicates an expected call of GetDimensionOptions.
+func (mr *MockFilterClientMockRecorder) GetDimensionOptions(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimensionOptions", reflect.TypeOf((*MockFilterClient)(nil).GetDimensionOptions), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q)
 }
 
 // GetDimensions mocks base method.

--- a/handlers/update_coverage.go
+++ b/handlers/update_coverage.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/ONSdigital/dp-net/v2/handlers"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/gorilla/mux"
+)
+
+// UpdateCoverage Handler
+func UpdateCoverage(fc FilterClient) http.HandlerFunc {
+	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
+		updateCoverage(w, req, fc, accessToken, collectionID)
+	})
+}
+
+func updateCoverage(w http.ResponseWriter, req *http.Request, fc FilterClient, accessToken, collectionID string) {
+	ctx := req.Context()
+	vars := mux.Vars(req)
+	filterID := vars["filterID"]
+
+	form, err := parseUpdateCoverageForm(req)
+	if err != nil {
+		log.Error(ctx, "failed to parse update coverage form", err, log.Data{
+			"filter_id": filterID,
+		})
+		setStatusCode(req, w, err)
+		return
+	}
+
+	if _, err = fc.AddDimensionValue(ctx, accessToken, "", collectionID, filterID, form.Dimension, form.Option, ""); err != nil {
+		log.Error(ctx, "failed to add dimension value", err, log.Data{
+			"dimension": form.Dimension,
+			"option":    form.Option,
+		})
+		setStatusCode(req, w, err)
+		return
+	}
+
+	http.Redirect(w, req, fmt.Sprint(req.URL), http.StatusMovedPermanently)
+}
+
+// updateCoverageForm represents form-data for the UpdateCoverage handler.
+type updateCoverageForm struct {
+	Dimension string
+	Option    string
+}
+
+// parseUpdateCoverageForm parses form data from a http.Request into a updateCoverageForm.
+func parseUpdateCoverageForm(req *http.Request) (updateCoverageForm, error) {
+	err := req.ParseForm()
+	if err != nil {
+		return updateCoverageForm{}, fmt.Errorf("error parsing form: %w", err)
+	}
+
+	dimension := req.FormValue("dimension")
+	if dimension == "" {
+		return updateCoverageForm{}, &clientErr{errors.New("missing required value 'dimension'")}
+	}
+
+	option := req.FormValue("option")
+	if option == "" {
+		return updateCoverageForm{}, &clientErr{errors.New("missing required value 'option'")}
+	}
+
+	return updateCoverageForm{
+		Dimension: dimension,
+		Option:    option,
+	}, nil
+}

--- a/handlers/update_coverage_test.go
+++ b/handlers/update_coverage_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUpdateCoverageHandler(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	Convey("Update coverage", t, func() {
+		stubFormData := url.Values{}
+		stubFormData.Add("dimension", "geography")
+		stubFormData.Add("option", "0")
+
+		Convey("Given a valid geography", func() {
+			Convey("When the user is redirected to the get coverage screen", func() {
+				const filterID = "1234"
+
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					AddDimensionValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return("", nil)
+
+				w := runUpdateCoverage(filterID, "geography", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the location header should match the get coverage screen", func() {
+					So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/filters/%s/dimensions/geography/coverage", filterID))
+				})
+
+				Convey("And the status code should be 301", func() {
+					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
+				})
+			})
+
+			Convey("When the filter API client responds with an error", func() {
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					AddDimensionValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return("", errors.New("internal error"))
+
+				w := runUpdateCoverage("test", "test", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the client should not be redirected", func() {
+					So(w.Header().Get("Location"), ShouldBeEmpty)
+				})
+
+				Convey("And the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+		})
+
+		Convey("Given an invalid request", func() {
+			Convey("When the request is missing the hidden required form values", func() {
+				tests := map[string]url.Values{
+					"Missing dimension": {"option": []string{"0"}},
+					"Missing option":    {"dimension": []string{"geography"}},
+				}
+
+				for name, formData := range tests {
+					Convey(name, func() {
+						w := runUpdateCoverage("test", "test", formData, UpdateCoverage(NewMockFilterClient(mockCtrl)))
+
+						Convey("Then the client should not be redirected", func() {
+							So(w.Header().Get("Location"), ShouldBeEmpty)
+						})
+
+						Convey("And the status code should be 400", func() {
+							So(w.Code, ShouldEqual, http.StatusBadRequest)
+						})
+					})
+				}
+			})
+		})
+	})
+}
+
+func runUpdateCoverage(filterID, dimension string, formData url.Values, handler http.HandlerFunc) *httptest.ResponseRecorder {
+	encodedFormData := formData.Encode()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/filters/%s/dimensions/geography/coverage", filterID), strings.NewReader(encodedFormData))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Content-Length", strconv.Itoa(len(encodedFormData)))
+
+	w := httptest.NewRecorder()
+
+	router := mux.NewRouter()
+	router.HandleFunc("/filters/{filterID}/dimensions/geography/coverage", handler)
+	router.ServeHTTP(w, req)
+
+	return w
+}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -169,7 +169,7 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, fi
 }
 
 // CreateGetCoverage maps data to the coverage model
-func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID, geogName, query string, areas population.GetAreasResponse, isSearch bool) model.Coverage {
+func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID, geogName, query, dim string, areas population.GetAreasResponse, opts []model.Option, isSearch bool) model.Coverage {
 	p := model.Coverage{
 		Page: basePage,
 	}
@@ -190,19 +190,20 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 	}
 
 	p.Geography = strings.ToLower(geography)
-	p.IsSearch = isSearch
+	p.Dimension = dim
+	p.DisplaySearch = isSearch || len(opts) > 0
 	p.Search = query
+	p.Options = opts
 
 	var results []model.SearchResult
 	for _, area := range areas.Areas {
 		var isSelected bool
-		for _, added := range p.AreasAdded {
-			if strings.EqualFold(added, area.Label) {
+		for _, opt := range opts {
+			if opt.ID == area.ID {
 				isSelected = true
 				break
 			}
 		}
-
 		results = append(results, model.SearchResult{
 			Label:      area.Label,
 			ID:         area.ID,
@@ -210,6 +211,7 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 		})
 	}
 	p.SearchResults = results
+	p.HasNoResults = isSearch && len(p.SearchResults) == 0
 
 	return p
 }

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -8,10 +8,12 @@ import (
 type Coverage struct {
 	coreModel.Page
 	Geography     string         `json:"geography"`
-	IsSearch      bool           `json:"is_search"`
+	Dimension     string         `json:"dimension"`
+	HasNoResults  bool           `json:"has_no_results"`
 	Search        string         `json:"search"`
+	DisplaySearch bool           `json:"display_search"`
 	SearchResults []SearchResult `json:"search_results"`
-	AreasAdded    []string       `json:"areas_added"`
+	Options       []Option       `json:"options"`
 }
 
 // SearchResult represents the data required to display a search result
@@ -19,4 +21,10 @@ type SearchResult struct {
 	Label      string `json:"label"`
 	ID         string `json:"id"`
 	IsSelected bool   `json:"is_selected"`
+}
+
+// Option represents the data required to display an option
+type Option struct {
+	Label string `json:"label"`
+	ID    string `json:"id"`
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -37,4 +37,5 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(handlers.DimensionsSelector(c.Render, c.Filter, c.Population))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("POST").HandlerFunc(handlers.ChangeDimension(c.Filter))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/geography/coverage").Methods("GET").HandlerFunc(handlers.GetCoverage(c.Render, c.Filter, c.Population))
+	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/geography/coverage").Methods("POST").HandlerFunc(handlers.UpdateCoverage(c.Filter))
 }


### PR DESCRIPTION
### What

Created functionality to POST selected option to `fc.AddDimensionValue` endpoint

✅ Resolves [trello ticket](https://trello.com/c/0IDQqmEF/5767-post-selected-option) to POST selected option

### How to review

- Sense check
- Tests pass
- Review media
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. 
  - Create a flexible dataset
  - Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-default/editions/2021/versions/1)
  - Click 'change' on 'coverage'
  - Search for a geography by name
  - Click 'add' on a geography option
  - **OR** call me 🤙 and I'll show you 

**Notes**
- The 'remove' buttons do not work (next thing to be worked on)
- The 'review changes' screen does not currently display selected options (ticket created to cover this work)
- During the 'remove' button work, improvements will be made for concurrent API calls, the `GetArea` endpoint will (hopefully) be ready

#### Media
https://user-images.githubusercontent.com/19624419/181580021-ed4ba196-24af-4ef6-aad4-fdebdc100fe9.mov

### Who can review

Frontend go dev
