### PR TITLE
feature/delete selected option

### DIFF
--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -19,85 +19,33 @@
                                 <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="coverage-search" name="coverage" {{ if .DisplaySearch }} checked="checked" {{ end }}>
                                 <label class="ons-radio__label" for="coverage-search">{{- localise "CoverageSearch" .Language 1 .Geography -}}</label>
                                 <div class="ons-radio__other ons-u-pb-no" id="other-radio-other-wrap">
-                                    <form class="ons-u-pb-xs">
-                                        <span class="ons-field">
-                                            <label class="ons-label ons-u-pb-xs" for="search-field">{{- localise "CoverageSearchLabel" .Language 1 -}}</label>
-                                            <span class="ons-grid--flex ons-search">
-                                                <input type="search" id="search-field" name="q" value="{{- .Search -}}" class="ons-input ons-search__input"/>
-                                                <button type="submit" class="ons-btn ons-btn--secondary ons-search__btn ons-u-mt-xs@xxs@s ons-btn--small">
-                                                    <span class="ons-btn__inner">
-                                                        {{ template "icons/search" }}
-                                                        <span class="ons-u-ml-xs">{{- localise "CoverageSearchButtonText" .Language 1 -}}</span>
-                                                    </span>
-                                                </button>
-                                            </span>
-                                        </span>
-                                    </form>
+                                    {{ template "partials/coverage/search" . }}
                                     {{ if .DisplaySearch }}
-                                        {{ if .SearchResults }}
-                                            <div class="ons-u-mt-xs ons-u-mb-xs ons-u-fw-b">{{- localise "SearchResults" .Language 4 -}}</div>
-                                            <form method="post">
-                                                <input type="hidden" name="dimension" value="{{- .Dimension -}}">
-                                                <ul class="ons-list--bare ons-u-mb-no coverage-search">
-                                                    {{ range .SearchResults }}
-                                                        <li class="ons-u-bt ons-list__item coverage-search__results">
-                                                            {{- .Label -}}
-                                                            <button type="submit" name="option" value="{{- .ID -}}" class="ons-btn ons-btn--secondary ons-btn--small">
-                                                                <span class="ons-btn__inner">
-                                                                    {{ if .IsSelected }}
-                                                                        <span class="ons-btn__text">{{- localise "SearchResultsRemove" $.Language 1 -}}</span>
-                                                                    {{ else }}
-                                                                        <span class="ons-btn__text">{{- localise "SearchResultsAdd" $.Language 1 -}}</span>
-                                                                    {{ end }}
-                                                                    <span class="ons-u-vh">{{ .Label -}}</span>
-                                                                </span>
-                                                            </button>
-                                                        </li>
-                                                    {{ end }}
-                                                </ul>
-                                            </form>
-                                        {{ end }}
-                                        {{ if .HasNoResults }}
-                                            <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
-                                        {{ end }}
-                                        {{ if .Options }}
-                                            {{ $len := len .Options }}
-                                            <div class="ons-u-fw-b ons-u-pt-s ons-u-mb-xs">
-                                                {{ if eq $len 1 }}
-                                                    {{- localise "AreasAddedTitle" .Language 1 -}}
-                                                {{ else }}
-                                                    {{- localise "AreasAddedTitle" .Language 4 -}}
-                                                {{ end }}
-                                            </div>
-                                            <form class="ons-u-pb-xs">
-                                                <ul class="ons-list--bare ons-u-mb-no coverage-selection">
-                                                    {{ range .Options }}
-                                                        <li class="ons-u-mb-no coverage-selection__selected">
-                                                            <button type="button" class="ons-btn ons-btn--secondary">
-                                                                <span class="ons-btn__inner">
-                                                                    <span class="ons-u-vh">{{- localise "SearchResultsRemove" $.Language 1 -}}</span>
-                                                                    <span class="ons-btn__text">{{ .Label }}</span>
-                                                                    <span class="ons-u-pl-xs">
-                                                                        {{ template "icons/cross" . }}
-                                                                    </span>
-                                                                </span>
-                                                            </button>
-                                                        </li>
-                                                    {{ end }}
-                                                </ul>
-                                            </form>
-                                        {{ end }}
+                                        <form method="post" class="ons-u-mt-xs">
+                                            <input type="hidden" name="dimension" value="{{- .Dimension -}}">
+                                            {{ if .SearchResults }}
+                                                {{ template "partials/coverage/results" . }}
+                                            {{ end }}
+                                            {{ if .HasNoResults }}
+                                                <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
+                                            {{ end }}
+                                            {{ if .Options }}
+                                                {{ template "partials/coverage/options" . }}
+                                            {{ end }}
+                                        </form>
                                     {{ end }}
                                 </div>
                             </div>
                         </div>
                     </div>
                 </fieldset>
-                <form>
-                    <button type="submit" class="ons-btn ons-u-mt-xl ons-u-mb-s">
-                        <span class="ons-btn__inner">{{- localise "Continue" .Language 1 -}}</span>
-                    </button>
-                </form>
+                <a href="{{ .ContinueURI }}" role="button" class="ons-btn ons-btn--link ons-u-mt-xl ons-u-mb-s">
+                    <span class="ons-btn__inner">
+                        <span class="ons-btn__text">
+                            {{- localise "Continue" .Language 1 -}}
+                        </span>
+                    </span>
+                </a>
             </div>
         </div>
     </div>

--- a/assets/templates/partials/coverage/options.tmpl
+++ b/assets/templates/partials/coverage/options.tmpl
@@ -1,0 +1,36 @@
+<fieldset>
+    {{ $len := len .Options }}
+    <legend class="ons-u-fw-b ons-u-pt-s ons-u-mb-xs">
+        {{ if eq $len 1 }}
+            {{- localise "AreasAddedTitle" .Language 1 -}}
+        {{ else }}
+            {{- localise "AreasAddedTitle" .Language 4 -}}
+        {{ end }}
+    </legend>
+    <div class="ons-u-pb-xs">
+        <ul class="ons-list--bare ons-u-mb-no coverage-selection">
+            {{ range .Options }}
+                <li class="ons-u-mb-no coverage-selection__selected">
+                    <button 
+                        type="submit" 
+                        name="delete-option" 
+                        value="{{- .ID -}}" 
+                        class="ons-btn ons-btn--secondary"
+                        >
+                        <span class="ons-btn__inner">
+                            <span class="ons-u-vh">
+                                {{- localise "SearchResultsRemove" $.Language 1 -}}
+                            </span>
+                            <span class="ons-btn__text">
+                                {{ .Label }}
+                            </span>
+                            <span class="ons-u-pl-xs">
+                                {{ template "icons/cross" . }}
+                            </span>
+                        </span>
+                    </button>
+                </li>
+            {{ end }}
+        </ul>
+    </div>
+</fieldset>

--- a/assets/templates/partials/coverage/results.tmpl
+++ b/assets/templates/partials/coverage/results.tmpl
@@ -1,0 +1,30 @@
+<fieldset>
+    <legend class="ons-u-mt-xs ons-u-mb-xs ons-u-fw-b">
+        {{- localise "SearchResults" .Language 4 -}}
+    </legend>
+    <ul class="ons-list--bare ons-u-mb-no coverage-search">
+        {{ range .SearchResults }}
+            <li class="ons-u-bt ons-list__item coverage-search__results">
+                {{- .Label -}}
+                <button 
+                    type="submit" 
+                    name="{{ if .IsSelected }}delete{{ else }}add{{ end }}-option" 
+                    value="{{- .ID -}}" 
+                    class="ons-btn ons-btn--secondary ons-btn--small">
+                    <span class="ons-btn__inner">
+                        {{ if .IsSelected }}
+                            <span class="ons-btn__text">
+                                {{- localise "SearchResultsRemove" $.Language 1 -}}
+                            </span>
+                        {{ else }}
+                            <span class="ons-btn__text">
+                                {{- localise "SearchResultsAdd" $.Language 1 -}}
+                            </span>
+                        {{ end }}
+                        <span class="ons-u-vh">{{ .Label -}}</span>
+                    </span>
+                </button>
+            </li>
+        {{ end }}
+    </ul>
+</fieldset>

--- a/assets/templates/partials/coverage/search.tmpl
+++ b/assets/templates/partials/coverage/search.tmpl
@@ -1,0 +1,27 @@
+<form method="get" class="ons-u-pb-xs">
+    <span class="ons-field">
+        <label class="ons-label ons-u-pb-xs" for="search-field">
+            {{- localise "CoverageSearchLabel" .Language 1 -}}
+        </label>
+        <span class="ons-grid--flex ons-search">
+            <input 
+                type="search" 
+                id="search-field" 
+                name="q" 
+                value="{{- .Search -}}" 
+                class="ons-input ons-search__input"
+                >
+            <button 
+                type="submit" 
+                class="ons-btn ons-btn--secondary ons-search__btn ons-u-mt-xs@xxs@s ons-btn--small"
+                >
+                <span class="ons-btn__inner">
+                    {{ template "icons/search" }}
+                    <span class="ons-u-ml-xs">
+                        {{- localise "CoverageSearchButtonText" .Language 1 -}}
+                    </span>
+                </span>
+            </button>
+        </span>
+    </span>
+</form>

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -31,10 +31,11 @@ type FilterClient interface {
 	GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (f filter.Model, eTag string, err error)
 	GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (dim filter.Dimension, eTag string, err error)
 	GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string, q *filter.QueryParams) (dims filter.Dimensions, eTag string, err error)
-	UpdateDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch string, dimension filter.Dimension) (dim filter.Dimension, eTag string, err error)
-	SubmitFilter(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, ifMatch string, sfr filter.SubmitFilterRequest) (resp *filter.SubmitFilterResponse, eTag string, err error)
-	AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (eTag string, err error)
 	GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q *filter.QueryParams) (opts filter.DimensionOptions, eTag string, err error)
+	UpdateDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch string, dimension filter.Dimension) (dim filter.Dimension, eTag string, err error)
+	AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (eTag string, err error)
+	RemoveDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (eTag string, err error)
+	SubmitFilter(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, ifMatch string, sfr filter.SubmitFilterRequest) (resp *filter.SubmitFilterResponse, eTag string, err error)
 }
 
 // DatasetClient is an interface with methods required for a dataset client

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -233,6 +233,21 @@ func (mr *MockFilterClientMockRecorder) GetJobState(ctx, userAuthToken, serviceA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobState", reflect.TypeOf((*MockFilterClient)(nil).GetJobState), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID)
 }
 
+// RemoveDimensionValue mocks base method.
+func (m *MockFilterClient) RemoveDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveDimensionValue", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveDimensionValue indicates an expected call of RemoveDimensionValue.
+func (mr *MockFilterClientMockRecorder) RemoveDimensionValue(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDimensionValue", reflect.TypeOf((*MockFilterClient)(nil).RemoveDimensionValue), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
+}
+
 // SubmitFilter mocks base method.
 func (m *MockFilterClient) SubmitFilter(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, ifMatch string, sfr filter.SubmitFilterRequest) (*filter.SubmitFilterResponse, string, error) {
 	m.ctrl.T.Helper()

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -194,6 +194,7 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 	p.DisplaySearch = isSearch || len(opts) > 0
 	p.Search = query
 	p.Options = opts
+	p.ContinueURI = fmt.Sprintf("/filters/%s/dimensions", filterID)
 
 	var results []model.SearchResult
 	for _, area := range areas.Areas {
@@ -223,6 +224,7 @@ func mapCommonProps(req *http.Request, p *coreModel.Page, pageType, title, lang 
 	p.Type = pageType
 	p.Metadata.Title = title
 	p.Language = lang
+	p.URI = req.URL.Path
 }
 
 // mapCookiePreferences reads cookie policy and preferences cookies and then maps the values to the page model

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -261,6 +261,7 @@ func TestGetCoverage(t *testing.T) {
 				So(coverage.BetaBannerEnabled, ShouldBeTrue)
 				So(coverage.Type, ShouldEqual, "filter-flex-coverage")
 				So(coverage.Language, ShouldEqual, lang)
+				So(coverage.URI, ShouldEqual, "/")
 			})
 
 			Convey("it sets the title to Coverage", func() {
@@ -281,6 +282,10 @@ func TestGetCoverage(t *testing.T) {
 
 			Convey("it sets Dimension property", func() {
 				So(coverage.Dimension, ShouldEqual, "dim")
+			})
+
+			Convey("it sets ContinueURI property", func() {
+				So(coverage.ContinueURI, ShouldEqual, "/filters/12345/dimensions")
 			})
 		})
 

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -14,6 +14,7 @@ type Coverage struct {
 	DisplaySearch bool           `json:"display_search"`
 	SearchResults []SearchResult `json:"search_results"`
 	Options       []Option       `json:"options"`
+	ContinueURI   string         `json:"continue_uri"`
 }
 
 // SearchResult represents the data required to display a search result


### PR DESCRIPTION
### What

- Refactored `coverage` template into relevant partials
- Enabled `delete` option functionality using `fc.RemoveDimensionValue` endpoint
- ✅ **resolves** [trello ticket](https://trello.com/c/Z2f5DhWn/5792-delete-selected-option-for-are-within-a-larger-area) DELETE selected option for area

### How to review

- Sense check
- Tests pass
- Media review
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. 
  - Create a flexible dataset
  - Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-default/editions/2021/versions/1)
  - Click 'change' on 'coverage'
  - Search for a geography by name
  - Click 'add' on a geography option, note the geography you have added 
  - Click 'remove' on your added geography, note your option should now be removed
  - **OR** call me 🤙 and I'll show you 

#### Media
https://user-images.githubusercontent.com/19624419/181775600-ff747cbc-954b-403f-96cb-c0e6ccf86e51.mov

### Who can review

Frontend go dev
