### PR TITLE
Feature/handle change of coverage type

### DIFF
--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -4,48 +4,46 @@
         <h1 class="ons-u-fs-xxxl ons-u-mt-s ons-u-fw-b">{{ .Page.Metadata.Title }}</h1>
         <div class="ons-grid__col ons-col-7@m ons-u-pl-no">
             <div class="ons-page__main ons-u-mt-l">
-                <fieldset class="ons-fieldset">
-                    <legend class="ons-fieldset__legend">{{- localise "CoverageLegend" .Language 1 -}}</legend>
-                    <div class="ons-radios__items">
-                        <span class="ons-radios__item ons-radios__item--no-border">
-                            <span class="ons-radio ons-radio--no-border">
-                                <input type="radio" id="coverage-default" class="ons-radio__input ons-js-radio" value="coverage-default" name="coverage" {{ if eq .DisplaySearch false }} checked="checked" {{ end }}>
-                                <label class=" ons-radio__label" for="coverage-default">{{- localise "CoverageDefault" .Language 1 .Geography -}}</label>
+                <form method="post">
+                    <input type="hidden" name="dimension" value="{{- .Dimension -}}">
+                    <fieldset class="ons-fieldset">
+                        <legend class="ons-fieldset__legend">{{- localise "CoverageLegend" .Language 1 -}}</legend>
+                        <div class="ons-radios__items">
+                            <span class="ons-radios__item ons-radios__item--no-border">
+                                <span class="ons-radio ons-radio--no-border">
+                                    <input type="radio" id="coverage-default" class="ons-radio__input ons-js-radio" value="default" name="coverage" {{ if eq .DisplaySearch false }} checked="checked" {{ end }}>
+                                    <label class="ons-radio__label" for="coverage-default">{{- localise "CoverageDefault" .Language 1 .Geography -}}</label>
+                                </span>
                             </span>
-                        </span>
-                        <br>
-                        <div class="ons-radios__item ons-radios__item--no-border ons-u-fw">
-                            <div class="ons-radio ons-radio--no-border">
-                                <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="coverage-search" name="coverage" {{ if .DisplaySearch }} checked="checked" {{ end }}>
-                                <label class="ons-radio__label" for="coverage-search">{{- localise "CoverageSearch" .Language 1 .Geography -}}</label>
-                                <div class="ons-radio__other ons-u-pb-no" id="other-radio-other-wrap">
-                                    {{ template "partials/coverage/search" . }}
-                                    {{ if .DisplaySearch }}
-                                        <form method="post" class="ons-u-mt-xs">
-                                            <input type="hidden" name="dimension" value="{{- .Dimension -}}">
-                                            {{ if .SearchResults }}
-                                                {{ template "partials/coverage/results" . }}
-                                            {{ end }}
-                                            {{ if .HasNoResults }}
-                                                <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
-                                            {{ end }}
-                                            {{ if .Options }}
-                                                {{ template "partials/coverage/options" . }}
-                                            {{ end }}
-                                        </form>
-                                    {{ end }}
+                            <br>
+                            <div class="ons-radios__item ons-radios__item--no-border ons-u-fw">
+                                <div class="ons-radio ons-radio--no-border">
+                                    <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="name-search" name="coverage" {{ if .DisplaySearch }} checked="checked" {{ end }}>
+                                    <label class="ons-radio__label" for="coverage-search">{{- localise "CoverageSearch" .Language 1 .Geography -}}</label>
+                                    <div class="ons-radio__other ons-u-pb-no" id="other-radio-other-wrap">
+                                        {{ template "partials/coverage/search" . }}
+                                        {{ if .DisplaySearch }}
+                                            <div class="ons-u-mt-xs">
+                                                {{ if .SearchResults }}
+                                                    {{ template "partials/coverage/results" . }}
+                                                {{ end }}
+                                                {{ if .HasNoResults }}
+                                                    <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
+                                                {{ end }}
+                                                {{ if .Options }}
+                                                    {{ template "partials/coverage/options" . }}
+                                                {{ end }}
+                                            </div>
+                                        {{ end }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </fieldset>
-                <a href="{{ .ContinueURI }}" role="button" class="ons-btn ons-btn--link ons-u-mt-xl ons-u-mb-s">
-                    <span class="ons-btn__inner">
-                        <span class="ons-btn__text">
-                            {{- localise "Continue" .Language 1 -}}
-                        </span>
-                    </span>
-                </a>
+                    </fieldset>
+                    <button type="submit" class="ons-btn ons-u-mt-xl ons-u-mb-s">
+                        <span class="ons-btn__inner">{{- localise "Continue" .Language 1 -}}</span>
+                    </button>
+                </form>
             </div>
         </div>
     </div>

--- a/assets/templates/partials/coverage/search.tmpl
+++ b/assets/templates/partials/coverage/search.tmpl
@@ -1,4 +1,4 @@
-<form method="get" class="ons-u-pb-xs">
+<div class="ons-u-pb-xs">
     <span class="ons-field">
         <label class="ons-label ons-u-pb-xs" for="search-field">
             {{- localise "CoverageSearchLabel" .Language 1 -}}
@@ -14,6 +14,8 @@
             <button 
                 type="submit" 
                 class="ons-btn ons-btn--secondary ons-search__btn ons-u-mt-xs@xxs@s ons-btn--small"
+                name="is-search"
+                value="true"
                 >
                 <span class="ons-btn__inner">
                     {{ template "icons/search" }}
@@ -24,4 +26,4 @@
             </button>
         </span>
     </span>
-</form>
+</div>

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -35,6 +35,7 @@ type FilterClient interface {
 	UpdateDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, name, ifMatch string, dimension filter.Dimension) (dim filter.Dimension, eTag string, err error)
 	AddDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (eTag string, err error)
 	RemoveDimensionValue(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch string) (eTag string, err error)
+	DeleteDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (eTag string, err error)
 	SubmitFilter(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, ifMatch string, sfr filter.SubmitFilterRequest) (resp *filter.SubmitFilterResponse, eTag string, err error)
 }
 

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -154,6 +154,21 @@ func (mr *MockFilterClientMockRecorder) AddDimensionValue(ctx, userAuthToken, se
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDimensionValue", reflect.TypeOf((*MockFilterClient)(nil).AddDimensionValue), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, value, ifMatch)
 }
 
+// DeleteDimensionOptions mocks base method.
+func (m *MockFilterClient) DeleteDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDimensionOptions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteDimensionOptions indicates an expected call of DeleteDimensionOptions.
+func (mr *MockFilterClientMockRecorder) DeleteDimensionOptions(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDimensionOptions", reflect.TypeOf((*MockFilterClient)(nil).DeleteDimensionOptions), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
+}
+
 // GetDimension mocks base method.
 func (m *MockFilterClient) GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (filter.Dimension, string, error) {
 	m.ctrl.T.Helper()

--- a/handlers/update_coverage.go
+++ b/handlers/update_coverage.go
@@ -4,10 +4,25 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/ONSdigital/dp-net/v2/handlers"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
+)
+
+type FormAction int
+
+const (
+	Unknown FormAction = iota
+	CoverageAll
+	Add
+	Delete
+	Search
+	CoverageSearch
+	CoverageDefault = "default"
+	NameSearch      = "name-search"
 )
 
 // UpdateCoverage Handler
@@ -31,25 +46,45 @@ func updateCoverage(w http.ResponseWriter, req *http.Request, fc FilterClient, a
 		return
 	}
 
-	if form.IsDeleteOption {
-		_, err := fc.RemoveDimensionValue(ctx, accessToken, "", collectionID, filterID, form.Dimension, form.Option, "")
+	switch form.Action {
+	case CoverageSearch:
+		http.Redirect(w, req, fmt.Sprintf("/filters/%s/dimensions", filterID), http.StatusMovedPermanently)
+		return
+	case Search:
+		v := url.Values{}
+		v.Set("q", form.Value)
+		req.URL.RawQuery = v.Encode()
+	case Delete:
+		_, err := fc.RemoveDimensionValue(ctx, accessToken, "", collectionID, filterID, form.Dimension, form.Value, "")
 		if err != nil {
 			log.Error(ctx, "failed to remove dimension value", err, log.Data{
 				"dimension": form.Dimension,
-				"option":    form.Option,
+				"option":    form.Value,
 			})
 			setStatusCode(req, w, err)
 			return
 		}
-	} else {
-		if _, err = fc.AddDimensionValue(ctx, accessToken, "", collectionID, filterID, form.Dimension, form.Option, ""); err != nil {
+	case Add:
+		_, err := fc.AddDimensionValue(ctx, accessToken, "", collectionID, filterID, form.Dimension, form.Value, "")
+		if err != nil {
 			log.Error(ctx, "failed to add dimension value", err, log.Data{
 				"dimension": form.Dimension,
-				"option":    form.Option,
+				"option":    form.Value,
 			})
 			setStatusCode(req, w, err)
 			return
 		}
+	case CoverageAll:
+		_, err := fc.DeleteDimensionOptions(ctx, accessToken, "", collectionID, filterID, form.Dimension)
+		if err != nil {
+			log.Error(ctx, "failed to delete dimension options", err, log.Data{
+				"dimension": form.Dimension,
+			})
+			setStatusCode(req, w, err)
+			return
+		}
+		http.Redirect(w, req, fmt.Sprintf("/filters/%s/dimensions", filterID), http.StatusMovedPermanently)
+		return
 	}
 
 	http.Redirect(w, req, fmt.Sprint(req.URL), http.StatusMovedPermanently)
@@ -57,13 +92,16 @@ func updateCoverage(w http.ResponseWriter, req *http.Request, fc FilterClient, a
 
 // updateCoverageForm represents form-data for the UpdateCoverage handler.
 type updateCoverageForm struct {
-	Dimension      string
-	Option         string
-	IsDeleteOption bool
+	Action    FormAction
+	Value     string
+	Dimension string
 }
 
 // parseUpdateCoverageForm parses form data from a http.Request into a updateCoverageForm.
 func parseUpdateCoverageForm(req *http.Request) (updateCoverageForm, error) {
+	var action FormAction
+	var value string
+
 	err := req.ParseForm()
 	if err != nil {
 		return updateCoverageForm{}, fmt.Errorf("error parsing form: %w", err)
@@ -74,15 +112,44 @@ func parseUpdateCoverageForm(req *http.Request) (updateCoverageForm, error) {
 		return updateCoverageForm{}, &clientErr{errors.New("missing required value 'dimension'")}
 	}
 
+	coverage := req.FormValue("coverage")
+	if coverage == "" {
+		return updateCoverageForm{}, &clientErr{errors.New("missing required value 'coverage'")}
+	}
+
+	switch coverage {
+	case CoverageDefault:
+		action = CoverageAll
+		value = coverage
+	case NameSearch:
+		action = CoverageSearch
+		value = coverage
+	default:
+		return updateCoverageForm{}, &clientErr{errors.New("unknown coverage type")}
+	}
+
+	isSearch, err := strconv.ParseBool(req.FormValue("is-search"))
+	if isSearch {
+		q := req.FormValue("q")
+		action = Search
+		value = q
+	}
+
 	addOption := req.FormValue("add-option")
+	if addOption != "" {
+		action = Add
+		value = addOption
+	}
+
 	deleteOption := req.FormValue("delete-option")
-	if addOption == "" && deleteOption == "" {
-		return updateCoverageForm{}, &clientErr{errors.New("missing required value 'add-option' or 'delete-option'")}
+	if deleteOption != "" {
+		action = Delete
+		value = deleteOption
 	}
 
 	return updateCoverageForm{
-		Dimension:      dimension,
-		Option:         addOption + deleteOption,
-		IsDeleteOption: deleteOption != "",
+		Action:    action,
+		Value:     value,
+		Dimension: dimension,
 	}, nil
 }

--- a/handlers/update_coverage_test.go
+++ b/handlers/update_coverage_test.go
@@ -23,6 +23,7 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			stubFormData := url.Values{}
 			stubFormData.Add("dimension", "geography")
 			stubFormData.Add("add-option", "0")
+			stubFormData.Add("coverage", "name-search")
 
 			Convey("When the user is redirected to the get coverage screen", func() {
 				const filterID = "1234"
@@ -67,6 +68,7 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			stubFormData := url.Values{}
 			stubFormData.Add("dimension", "geography")
 			stubFormData.Add("delete-option", "0")
+			stubFormData.Add("coverage", "name-search")
 
 			Convey("When the user is redirected to the get coverage screen", func() {
 				const filterID = "1234"
@@ -107,12 +109,102 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			})
 		})
 
+		Convey("Given a valid all geography request", func() {
+			stubFormData := url.Values{}
+			stubFormData.Add("dimension", "geography")
+			stubFormData.Add("coverage", "default")
+
+			Convey("When the user selects the all geography option", func() {
+				const filterID = "1234"
+
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					DeleteDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return("", nil)
+
+				w := runUpdateCoverage(filterID, "geography", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the location header should match the review screen", func() {
+					So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/filters/%s/dimensions", filterID))
+				})
+
+				Convey("And the status code should be 301", func() {
+					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
+				})
+			})
+
+			Convey("When the filter API client responds with an error", func() {
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					DeleteDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return("", errors.New("internal error"))
+
+				w := runUpdateCoverage("test", "test", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the client should not be redirected", func() {
+					So(w.Header().Get("Location"), ShouldBeEmpty)
+				})
+
+				Convey("And the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+		})
+
+		Convey("Given a valid search request", func() {
+			stubFormData := url.Values{}
+			stubFormData.Add("dimension", "geography")
+			stubFormData.Add("coverage", "name-search")
+			stubFormData.Add("q", "area")
+			stubFormData.Add("is-search", "true")
+
+			Convey("When the user is redirected to the get coverage screen", func() {
+				const filterID = "1234"
+
+				filterClient := NewMockFilterClient(mockCtrl)
+				w := runUpdateCoverage(filterID, "geography", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the location header should match the get coverage screen with query persisted", func() {
+					So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/filters/%s/dimensions/geography/coverage?q=area", filterID))
+				})
+
+				Convey("And the status code should be 301", func() {
+					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
+				})
+			})
+		})
+
+		Convey("Given a valid continue request", func() {
+			stubFormData := url.Values{}
+			stubFormData.Add("dimension", "geography")
+			stubFormData.Add("coverage", "name-search")
+
+			Convey("When the user makes the request", func() {
+				const filterID = "1234"
+
+				filterClient := NewMockFilterClient(mockCtrl)
+				w := runUpdateCoverage(filterID, "geography", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the location header should match the review screen", func() {
+					So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/filters/%s/dimensions", filterID))
+				})
+
+				Convey("And the status code should be 301", func() {
+					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
+				})
+			})
+		})
+
 		Convey("Given an invalid request", func() {
 			Convey("When the request is missing the hidden required form values", func() {
 				tests := map[string]url.Values{
 					"Missing dimension":   {"add-option": []string{"0"}},
 					"Missing option":      {"dimension": []string{"geography"}},
 					"Invalid option name": {"option": []string{"0"}},
+					"Missing coverage":    {"add-option": []string{"0"}, "dimension": []string{"geography"}},
+					"Unknown coverage":    {"coverage": []string{"1234"}, "add-option": []string{"0"}, "dimension": []string{"geography"}},
 				}
 
 				for name, formData := range tests {


### PR DESCRIPTION
### What

Changed partial (individual) forms to one large form that enables the bespoke functionality within. 
ie. The name search still works as previously, the ability to add/remove an option works as previously
The above change ☝️ allows the user to change from 'searching by name' to select 'all geography within England and Wales' (the default) and vice versa.

✅ **Resolves** [trello ticket](https://trello.com/c/qAou11tK/5809-handle-select-all-coverage) handle 'select all' geography

### How to review

Sense check
Tests pass
Media review

https://user-images.githubusercontent.com/19624419/184830766-851c1f92-d47e-4d8f-81d6-2469fb05c543.mov

### Who can review

Frontend go dev
