### PR TITLE
Fix/ensure that area type options are not limited

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -56,7 +56,7 @@ func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, 
 		pageDim.URI = fmt.Sprintf("%s/%s", path, dim.Name)
 		q := url.Values{}
 
-		if len(dim.Options) > 9 && !helpers.HasStringInSlice(dim.Name, queryStrValues) {
+		if len(dim.Options) > 9 && !helpers.HasStringInSlice(dim.Name, queryStrValues) && !*dim.IsAreaType {
 			firstSlice := dim.Options[:3]
 
 			mid := len(dim.Options) / 2

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -87,6 +87,14 @@ func TestOverview(t *testing.T) {
 				Options: []string{
 					"area 1",
 					"area 2",
+					"area 3",
+					"area 4",
+					"area 5",
+					"area 6",
+					"area 7",
+					"area 8",
+					"area 9",
+					"area 10",
 				},
 			}},
 	}
@@ -123,7 +131,7 @@ func TestOverview(t *testing.T) {
 		So(m.Dimensions[0].IsAreaType, ShouldBeTrue)
 		So(m.Dimensions[0].IsCoverage, ShouldBeFalse)
 		So(m.Dimensions[0].Options, ShouldResemble, filterDims.Items[3].Options)
-		So(m.Dimensions[0].OptionsCount, ShouldEqual, 2)
+		So(m.Dimensions[0].OptionsCount, ShouldEqual, 10)
 		So(m.Dimensions[0].ID, ShouldEqual, filterDims.Items[3].ID)
 		So(m.Dimensions[0].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims.Items[3].Name))
 		So(m.Dimensions[0].IsTruncated, ShouldBeFalse)
@@ -179,6 +187,13 @@ func TestOverview(t *testing.T) {
 		So(m.Dimensions[4].OptionsCount, ShouldEqual, len(filterDims.Items[2].Options))
 		So(m.Dimensions[4].Options, ShouldHaveLength, 12)
 		So(m.Dimensions[4].IsTruncated, ShouldBeFalse)
+	})
+
+	Convey("test area type dimension options do not truncate and map to 'coverage' dimension", t, func() {
+		m := CreateFilterFlexOverview(req, mdl, lang, "", showAll, filterJob, filterDims, datasetDims, false)
+		So(m.Dimensions[1].Options, ShouldHaveLength, 10)
+		So(m.Dimensions[1].IsTruncated, ShouldBeFalse)
+		So(m.Dimensions[1].IsCoverage, ShouldBeTrue)
 	})
 
 	Convey("given hasNoAreaOptions parameter", t, func() {


### PR DESCRIPTION
### What

During testing, it's been noted that the selected area options on the 'review screen' are limited to 9. This change bypasses the truncation logic.

### How to review

Test pass
Sense check

### Who can review

!me
