### PR TITLE
Feature/add parent search option

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -126,6 +126,10 @@ one = "All {{.arg0}} within England and Wales"
 description = "Search for {{.Geography}} by name"
 one = "Search for {{.arg0}} by name"
 
+[CoverageParentSearch]
+description = "Select all {{.Geography}} within a larger area"
+one = "Select all {{.arg0}} within a larger area"
+
 [CoverageSearchLabel]
 description = "Enter an area name or code"
 one = "Enter an area name or code"
@@ -133,6 +137,18 @@ one = "Enter an area name or code"
 [CoverageSearchButtonText]
 description = "Search"
 one = "Search"
+
+[CoverageSelectLabel]
+description = "Larger area type"
+one = "Larger area type"
+
+[CoverageSelectHint]
+description = "For example, a region or local authority"
+one = "For example, a region or local authority"
+
+[CoverageSelectDefault]
+description = "Select a larger area type"
+one = "Select a larger area type"
 
 [AreaTypeCoverageTitle]
 description = "Coverage"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -126,6 +126,10 @@ one = "All {{.arg0}} within England and Wales"
 description = "Search for {{.Geography}} by name"
 one = "Search for {{.arg0}} by name"
 
+[CoverageParentSearch]
+description = "Select all {{.Geography}} within a larger area"
+one = "Select all {{.arg0}} within a larger area"
+
 [CoverageSearchLabel]
 description = "Enter an area name or code"
 one = "Enter an area name or code"
@@ -133,6 +137,18 @@ one = "Enter an area name or code"
 [CoverageSearchButtonText]
 description = "Search"
 one = "Search"
+
+[CoverageSelectLabel]
+description = "Larger area type"
+one = "Larger area type"
+
+[CoverageSelectHint]
+description = "For example, a region or local authority"
+one = "For example, a region or local authority"
+
+[CoverageSelectDefault]
+description = "Select a larger area type"
+one = "Select a larger area type"
 
 [AreaTypeCoverageTitle]
 description = "Coverage"

--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -20,8 +20,8 @@
                                 <div class="ons-radio ons-radio--no-border">
                                     <input type="radio" id="coverage-search" class="ons-radio__input ons-js-radio ons-js-other" value="name-search" name="coverage" {{ if .DisplaySearch }} checked="checked" {{ end }}>
                                     <label class="ons-radio__label" for="coverage-search">{{- localise "CoverageSearch" .Language 1 .Geography -}}</label>
-                                    <div class="ons-radio__other ons-u-pb-no" id="other-radio-other-wrap">
-                                        {{ template "partials/coverage/search" . }}
+                                    <div class="ons-radio__other ons-u-pb-no">
+                                        {{ template "partials/coverage/search" .NameSearch }}
                                         {{ if .DisplaySearch }}
                                             <div class="ons-u-mt-xs">
                                                 {{ if .SearchResults }}
@@ -35,6 +35,24 @@
                                                 {{ end }}
                                             </div>
                                         {{ end }}
+                                    </div>
+                                </div>
+                            </div>
+                            <br>
+                            <div class="ons-radios__item ons-radios__item--no-border ons-u-fw">
+                                <div class="ons-radio ons-radio--no-border">
+                                    <input
+                                        type="radio"
+                                        id="coverage-parent-search"
+                                        class="ons-radio__input ons-js-radio ons-js-other"
+                                        value="parent-search"
+                                        name="coverage">
+                                    <label class="ons-radio__label" for="coverage-parent-search">
+                                        {{- localise "CoverageParentSearch" .Language 1 .Geography -}}
+                                    </label>
+                                    <div class="ons-radio__other ons-u-pb-no">
+                                        {{ template "partials/coverage/select" . }}
+                                        {{ template "partials/coverage/search" .ParentSearch }}
                                     </div>
                                 </div>
                             </div>

--- a/assets/templates/partials/coverage/options.tmpl
+++ b/assets/templates/partials/coverage/options.tmpl
@@ -14,7 +14,7 @@
                     <button 
                         type="submit" 
                         name="delete-option" 
-                        value="{{- .ID -}}" 
+                        value="{{- .Value -}}" 
                         class="ons-btn ons-btn--secondary"
                         >
                         <span class="ons-btn__inner">
@@ -22,7 +22,7 @@
                                 {{- localise "SearchResultsRemove" $.Language 1 -}}
                             </span>
                             <span class="ons-btn__text">
-                                {{ .Label }}
+                                {{ .Text }}
                             </span>
                             <span class="ons-u-pl-xs">
                                 {{ template "icons/cross" . }}

--- a/assets/templates/partials/coverage/results.tmpl
+++ b/assets/templates/partials/coverage/results.tmpl
@@ -5,11 +5,11 @@
     <ul class="ons-list--bare ons-u-mb-no coverage-search">
         {{ range .SearchResults }}
             <li class="ons-u-bt ons-list__item coverage-search__results">
-                {{- .Label -}}
+                {{- .Text -}}
                 <button 
                     type="submit" 
                     name="{{ if .IsSelected }}delete{{ else }}add{{ end }}-option" 
-                    value="{{- .ID -}}" 
+                    value="{{- .Value -}}" 
                     class="ons-btn ons-btn--secondary ons-btn--small">
                     <span class="ons-btn__inner">
                         {{ if .IsSelected }}
@@ -21,7 +21,7 @@
                                 {{- localise "SearchResultsAdd" $.Language 1 -}}
                             </span>
                         {{ end }}
-                        <span class="ons-u-vh">{{ .Label -}}</span>
+                        <span class="ons-u-vh">{{ .Text -}}</span>
                     </span>
                 </button>
             </li>

--- a/assets/templates/partials/coverage/search.tmpl
+++ b/assets/templates/partials/coverage/search.tmpl
@@ -1,14 +1,14 @@
 <div class="ons-u-pb-xs">
     <span class="ons-field">
-        <label class="ons-label ons-u-pb-xs" for="search-field">
+        <label class="ons-label ons-u-pb-xs" for="{{- .ID -}}">
             {{- localise "CoverageSearchLabel" .Language 1 -}}
         </label>
         <span class="ons-grid--flex ons-search">
             <input 
                 type="search" 
-                id="search-field" 
-                name="q" 
-                value="{{- .Search -}}" 
+                id="{{- .ID -}}" 
+                name="{{- .Name -}}" 
+                value="{{- .Value -}}" 
                 class="ons-input ons-search__input"
                 >
             <button 

--- a/assets/templates/partials/coverage/select.tmpl
+++ b/assets/templates/partials/coverage/select.tmpl
@@ -1,0 +1,21 @@
+<div class="ons-field ons-u-mb-s">
+    <label class="ons-label ons-u-mb-no" for="larger-area-select">
+        {{- localise "CoverageSelectLabel" .Language 1 -}}
+    </label>
+    <span class="ons-label__description ons-input--with-description">
+        {{- localise "CoverageSelectHint" .Language 1 -}}
+    </span>
+    <select 
+        id="larger-area-select" 
+        name="larger-area" 
+        class="ons-input ons-input--select ons-input--block">
+        {{ range .ParentSelect }}
+            <option 
+                value="{{- .Value -}}" 
+                {{ if .IsDisabled }} disabled {{ end }} 
+                {{ if .IsSelected }} selected {{ end }}>
+                    {{- .Text -}}
+            </option>
+        {{ end }}
+    </select>
+</div>

--- a/handlers/get_coverage.go
+++ b/handlers/get_coverage.go
@@ -72,9 +72,9 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 		return
 	}
 
-	options := []model.Option{}
+	options := []model.SelectableElement{}
 	for _, opt := range opts.Items {
-		var option model.Option
+		var option model.SelectableElement
 		// TODO: Temporary fix until GetArea endpoint is created
 		areas, err := pc.GetAreas(ctx, population.GetAreasInput{
 			UserAuthToken: accessToken,
@@ -90,11 +90,11 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 			setStatusCode(req, w, err)
 			return
 		}
-		option.ID = opt.Option
+		option.Value = opt.Option
 		// needed to ensure label matches the ID
 		for _, area := range areas.Areas {
-			if area.ID == option.ID {
-				option.Label = area.Label
+			if area.ID == option.Value {
+				option.Text = area.Label
 				break
 			}
 		}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -172,7 +172,7 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, fi
 }
 
 // CreateGetCoverage maps data to the coverage model
-func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID, geogName, query, dim string, areas population.GetAreasResponse, opts []model.Option, isSearch bool) model.Coverage {
+func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID, geogName, query, dim string, areas population.GetAreasResponse, opts []model.SelectableElement, isSearch bool) model.Coverage {
 	p := model.Coverage{
 		Page: basePage,
 	}
@@ -195,22 +195,58 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 	p.Geography = strings.ToLower(geography)
 	p.Dimension = dim
 	p.DisplaySearch = isSearch || len(opts) > 0
-	p.Search = query
 	p.Options = opts
-	p.ContinueURI = fmt.Sprintf("/filters/%s/dimensions", filterID)
+	p.NameSearch = model.SearchField{
+		Name:  "q",
+		ID:    "name-search",
+		Value: query,
+	}
+	p.ParentSearch = model.SearchField{
+		Name:  "pq",
+		ID:    "parent-search",
+		Value: query,
+	}
+	// TODO: Replace dummy data with real list
+	p.ParentSelect = []model.SelectableElement{
+		{
+			Text:       helper.Localise("CoverageSelectDefault", lang, 1),
+			IsSelected: true,
+			IsDisabled: true,
+		},
+		{
+			Text:  "Country",
+			Value: "C",
+		},
+		{
+			Text:  "Region",
+			Value: "R",
+		},
+		{
+			Text:  "Unitary Authority",
+			Value: "UA",
+		},
+		{
+			Text:  "Merged Local Authority",
+			Value: "MLA",
+		},
+		{
+			Text:  "Local Authority",
+			Value: "LA",
+		},
+	}
 
-	var results []model.SearchResult
+	var results []model.SelectableElement
 	for _, area := range areas.Areas {
 		var isSelected bool
 		for _, opt := range opts {
-			if opt.ID == area.ID {
+			if opt.Value == area.ID {
 				isSelected = true
 				break
 			}
 		}
-		results = append(results, model.SearchResult{
-			Label:      area.Label,
-			ID:         area.ID,
+		results = append(results, model.SelectableElement{
+			Text:       area.Label,
+			Value:      area.ID,
 			IsSelected: isSelected,
 		})
 	}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -295,7 +295,7 @@ func TestGetCoverage(t *testing.T) {
 		req := httptest.NewRequest("", "/", nil)
 
 		Convey("When the parameters are valid", func() {
-			coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Country", "", "dim", population.GetAreasResponse{}, []model.Option{}, false)
+			coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Country", "", "dim", population.GetAreasResponse{}, []model.SelectableElement{}, false)
 			Convey("it sets page metadata", func() {
 				So(coverage.BetaBannerEnabled, ShouldBeTrue)
 				So(coverage.Type, ShouldEqual, "filter-flex-coverage")
@@ -322,14 +322,10 @@ func TestGetCoverage(t *testing.T) {
 			Convey("it sets Dimension property", func() {
 				So(coverage.Dimension, ShouldEqual, "dim")
 			})
-
-			Convey("it sets ContinueURI property", func() {
-				So(coverage.ContinueURI, ShouldEqual, "/filters/12345/dimensions")
-			})
 		})
 
 		Convey("When an unknown geography parameter is given", func() {
-			coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Unknown geography", "", "", population.GetAreasResponse{}, []model.Option{}, false)
+			coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Unknown geography", "", "", population.GetAreasResponse{}, []model.SelectableElement{}, false)
 			Convey("Then it sets the geography to unknown geography", func() {
 				So(coverage.Geography, ShouldEqual, "unknown geography")
 			})
@@ -354,7 +350,7 @@ func TestGetCoverage(t *testing.T) {
 				"search",
 				"",
 				mockedSearchResults,
-				[]model.Option{},
+				[]model.SelectableElement{},
 				true)
 			Convey("Then it sets DisplaySearch property", func() {
 				So(coverage.DisplaySearch, ShouldBeTrue)
@@ -365,10 +361,10 @@ func TestGetCoverage(t *testing.T) {
 			})
 
 			Convey("Then it maps the search results", func() {
-				expectedResult := []model.SearchResult{
+				expectedResult := []model.SelectableElement{
 					{
-						Label: mockedSearchResults.Areas[0].Label,
-						ID:    mockedSearchResults.Areas[0].ID,
+						Text:  mockedSearchResults.Areas[0].Label,
+						Value: mockedSearchResults.Areas[0].ID,
 					},
 				}
 				So(coverage.SearchResults, ShouldResemble, expectedResult)
@@ -385,7 +381,7 @@ func TestGetCoverage(t *testing.T) {
 				"search",
 				"",
 				population.GetAreasResponse{},
-				[]model.Option{},
+				[]model.SelectableElement{},
 				true)
 			Convey("Then it sets DisplaySearch property correctly", func() {
 				So(coverage.DisplaySearch, ShouldBeTrue)
@@ -396,15 +392,15 @@ func TestGetCoverage(t *testing.T) {
 			})
 
 			Convey("Then search results struct is empty", func() {
-				So(coverage.SearchResults, ShouldResemble, []model.SearchResult(nil))
+				So(coverage.SearchResults, ShouldResemble, []model.SelectableElement(nil))
 			})
 		})
 
 		Convey("When an option is added", func() {
-			mockedOpt := []model.Option{
+			mockedOpt := []model.SelectableElement{
 				{
-					Label: "label",
-					ID:    "0",
+					Text:  "label",
+					Value: "0",
 				},
 			}
 			coverage := CreateGetCoverage(
@@ -436,10 +432,10 @@ func TestGetCoverage(t *testing.T) {
 					},
 				},
 			}
-			mockedOpt := []model.Option{
+			mockedOpt := []model.SelectableElement{
 				{
-					Label: "label",
-					ID:    "0",
+					Text:  "label",
+					Value: "0",
 				},
 			}
 			coverage := CreateGetCoverage(
@@ -479,10 +475,10 @@ func TestGetCoverage(t *testing.T) {
 					},
 				},
 			}
-			mockedOpt := []model.Option{
+			mockedOpt := []model.SelectableElement{
 				{
-					Label: "area one",
-					ID:    "0",
+					Text:  "area one",
+					Value: "0",
 				},
 			}
 			coverage := CreateGetCoverage(
@@ -509,15 +505,15 @@ func TestGetCoverage(t *testing.T) {
 			})
 
 			Convey("Then it maps the search results", func() {
-				expectedResults := []model.SearchResult{
+				expectedResults := []model.SelectableElement{
 					{
-						Label:      mockedSearchResults.Areas[0].Label,
-						ID:         mockedSearchResults.Areas[0].ID,
+						Text:       mockedSearchResults.Areas[0].Label,
+						Value:      mockedSearchResults.Areas[0].ID,
 						IsSelected: true,
 					},
 					{
-						Label:      mockedSearchResults.Areas[1].Label,
-						ID:         mockedSearchResults.Areas[1].ID,
+						Text:       mockedSearchResults.Areas[1].Label,
+						Value:      mockedSearchResults.Areas[1].ID,
 						IsSelected: false,
 					},
 				}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -11,6 +11,8 @@ var cyLocale = []string{
 	"[Test]",
 	"one = \"Test (cy)\"",
 	"other = \"Tests (cy)\"",
+	"[CoverageSelectDefault]",
+	"one = \"Select (cy)\"",
 }
 
 var enLocale = []string{
@@ -22,6 +24,8 @@ var enLocale = []string{
 	"[Test]",
 	"one = \"Test\"",
 	"other = \"Tests\"",
+	"[CoverageSelectDefault]",
+	"one = \"Select\"",
 }
 
 // MockAssetFunction returns mocked toml []bytes

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -7,25 +7,34 @@ import (
 // Coverage represents the data to display the coverage page
 type Coverage struct {
 	coreModel.Page
-	Geography     string         `json:"geography"`
-	Dimension     string         `json:"dimension"`
-	HasNoResults  bool           `json:"has_no_results"`
-	Search        string         `json:"search"`
-	DisplaySearch bool           `json:"display_search"`
-	SearchResults []SearchResult `json:"search_results"`
-	Options       []Option       `json:"options"`
-	ContinueURI   string         `json:"continue_uri"`
+	Geography     string              `json:"geography"`
+	Dimension     string              `json:"dimension"`
+	HasNoResults  bool                `json:"has_no_results"`
+	Search        string              `json:"search"`
+	DisplaySearch bool                `json:"display_search"`
+	SearchResults []SelectableElement `json:"search_results"`
+	Options       []SelectableElement `json:"options"`
+	ParentSelect  []SelectableElement `json:"parent_select"`
+	NameSearch    SearchField         `json:"name_search"`
+	ParentSearch  SearchField         `json:"parent_search"`
 }
 
-// SearchResult represents the data required to display a search result
-type SearchResult struct {
-	Label      string `json:"label"`
-	ID         string `json:"id"`
+/* SelectableElement represents the data required for a selectable element.
+Text is the human readable label.
+Value is the value sent to the server.
+IsSelected is a boolean representing whether the element is selected.
+IsDisabled is a boolean representing whether the element is disabled */
+type SelectableElement struct {
+	Text       string `json:"text"`
+	Value      string `json:"value"`
 	IsSelected bool   `json:"is_selected"`
+	IsDisabled bool   `json:"is_disabled"`
 }
 
-// Option represents the data required to display an option
-type Option struct {
-	Label string `json:"label"`
-	ID    string `json:"id"`
+// SearchField represents the data required to populate the search input partial
+type SearchField struct {
+	Value    string `json:"value"`
+	Name     string `json:"name"`
+	ID       string `json:"id"`
+	Language string `json:"language"`
 }


### PR DESCRIPTION
### What

- Added additional radio option to perform a parent search/search within a larger area
- Consolidated search input into a reusable component
- Consolidated model types to be more generic

✅ **Resolves** trello ticket [5790 - As a web user I want to be able to choose to Search all {area type} within a larger area from the Coverage page](https://trello.com/c/kwuVJM6e/5790-as-a-web-user-i-want-to-be-able-to-choose-to-search-all-area-type-within-a-larger-area-from-the-coverage-page)

**Note** it is intentional that the new parent search does not work

### How to review

- Sense check
- Tests pass
- Image review

<img width="624" alt="image" src="https://user-images.githubusercontent.com/19624419/185597103-6b3673de-7022-4dcf-89b4-a89a8cfa4c4d.png">

### Who can review

Frontend go dev
