### PR TITLE
Feature/populate parent type select list

### DIFF
--- a/assets/templates/partials/coverage/select.tmpl
+++ b/assets/templates/partials/coverage/select.tmpl
@@ -1,21 +1,30 @@
 <div class="ons-field ons-u-mb-s">
-    <label class="ons-label ons-u-mb-no" for="larger-area-select">
-        {{- localise "CoverageSelectLabel" .Language 1 -}}
-    </label>
-    <span class="ons-label__description ons-input--with-description">
-        {{- localise "CoverageSelectHint" .Language 1 -}}
-    </span>
-    <select 
-        id="larger-area-select" 
-        name="larger-area" 
-        class="ons-input ons-input--select ons-input--block">
-        {{ range .ParentSelect }}
-            <option 
-                value="{{- .Value -}}" 
-                {{ if .IsDisabled }} disabled {{ end }} 
-                {{ if .IsSelected }} selected {{ end }}>
-                    {{- .Text -}}
-            </option>
-        {{ end }}
-    </select>
+    {{ if gt (len .ParentSelect) 1 }}
+        <label class="ons-label ons-u-mb-no" for="larger-area-select">
+            {{- localise "CoverageSelectLabel" .Language 1 -}}
+        </label>
+        <span class="ons-label__description ons-input--with-description">
+            {{- localise "CoverageSelectHint" .Language 1 -}}
+        </span>
+        <select 
+            id="larger-area-select" 
+            name="larger-area" 
+            class="ons-input ons-input--select ons-input--block">
+            {{ range .ParentSelect }}
+                <option 
+                    value="{{- .Value -}}" 
+                    {{ if .IsDisabled }} disabled {{ end }} 
+                    {{ if .IsSelected }} selected {{ end }}>
+                        {{- .Text -}}
+                </option>
+            {{ end }}
+        </select>
+    {{ else }}
+        {{ $single := index .ParentSelect 0 }}
+        <input type="hidden" name="larger-area" value="{{- $single.Value -}}">
+        <dl>
+            <dt class="ons-u-fs-r--b">{{- localise "CoverageSelectLabel" .Language 1 -}}</dt>
+            <dd class="ons-u-ml-no">{{- $single.Text -}}</dd>
+        </dl>
+    {{ end }}
 </div>

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -49,4 +49,5 @@ type DatasetClient interface {
 type PopulationClient interface {
 	GetPopulationAreaTypes(ctx context.Context, userAuthToken, serviceAuthToken, datasetID string) (population.GetAreaTypesResponse, error)
 	GetAreas(ctx context.Context, input population.GetAreasInput) (population.GetAreasResponse, error)
+	GetAreaTypeParents(ctx context.Context, input population.GetAreaTypeParentsInput) (population.GetAreaTypeParentsResponse, error)
 }

--- a/handlers/get_coverage.go
+++ b/handlers/get_coverage.go
@@ -65,6 +65,20 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 		}
 	}
 
+	parents, err := pc.GetAreaTypeParents(ctx, population.GetAreaTypeParentsInput{
+		UserAuthToken: accessToken,
+		DatasetID:     filterJob.PopulationType,
+		AreaTypeID:    geogID,
+	})
+	if err != nil {
+		log.Error(ctx, "failed to get parents", err, log.Data{
+			"dataset_id":   geogID,
+			"area_type_id": geogLabel,
+		})
+		setStatusCode(req, w, err)
+		return
+	}
+
 	opts, _, err := fc.GetDimensionOptions(ctx, accessToken, "", collectionID, filterID, dimension, &filter.QueryParams{})
 	if err != nil {
 		log.Error(ctx, "failed to get dimension options", err, log.Data{"dimension_name": dimension})
@@ -117,6 +131,6 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 	}
 
 	basePage := rc.NewBasePageModel()
-	m := mapper.CreateGetCoverage(req, basePage, lang, filterID, geogLabel, q, dimension, areas, options, isSearch)
+	m := mapper.CreateGetCoverage(req, basePage, lang, filterID, geogLabel, q, dimension, areas, options, isSearch, parents)
 	rc.BuildPage(w, m, "coverage")
 }

--- a/handlers/get_coverage_test.go
+++ b/handlers/get_coverage_test.go
@@ -70,6 +70,9 @@ func TestGetCoverageHandler(t *testing.T) {
 					Return(filter.DimensionOptions{}, "", nil)
 
 				mockPc := NewMockPopulationClient(mockCtrl)
+				mockPc.EXPECT().
+					GetAreaTypeParents(gomock.Any(), gomock.Any()).
+					Return(population.GetAreaTypeParentsResponse{}, nil)
 
 				router := mux.NewRouter()
 				router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(mockRend, mockFc, mockPc))
@@ -118,6 +121,9 @@ func TestGetCoverageHandler(t *testing.T) {
 					EXPECT().
 					GetAreas(gomock.Any(), gomock.Any()).
 					Return(population.GetAreasResponse{}, nil)
+				mockPc.EXPECT().
+					GetAreaTypeParents(gomock.Any(), gomock.Any()).
+					Return(population.GetAreaTypeParentsResponse{}, nil)
 
 				router := mux.NewRouter()
 				router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(mockRend, mockFc, mockPc))
@@ -179,6 +185,9 @@ func TestGetCoverageHandler(t *testing.T) {
 							},
 						},
 					}, nil)
+				mockPc.EXPECT().
+					GetAreaTypeParents(gomock.Any(), gomock.Any()).
+					Return(population.GetAreaTypeParentsResponse{}, nil)
 
 				router := mux.NewRouter()
 				router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(mockRend, mockFc, mockPc))
@@ -280,8 +289,51 @@ func TestGetCoverageHandler(t *testing.T) {
 				GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(filter.DimensionOptions{}, "", errors.New("sorry"))
 
+			mockPc := NewMockPopulationClient(mockCtrl)
+			mockPc.EXPECT().
+				GetAreaTypeParents(gomock.Any(), gomock.Any()).
+				Return(population.GetAreaTypeParentsResponse{}, nil)
+
 			router := mux.NewRouter()
-			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, NewMockPopulationClient(mockCtrl)))
+			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, mockPc))
+			router.ServeHTTP(w, req)
+
+			Convey("Then the status code should be 500", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
+		Convey("When the GetAreaTypeParents API call responds with an error", func() {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/filters/12345/dimensions/geography/coverage", nil)
+
+			mockFc := NewMockFilterClient(mockCtrl)
+			mockFc.
+				EXPECT().
+				GetDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(mockFilterDims, "", nil)
+			mockFc.
+				EXPECT().
+				GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[0].Name).
+				Return(mockFilterDims.Items[0], "", nil)
+			mockFc.
+				EXPECT().
+				GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), mockFilterDims.Items[1].Name).
+				Return(mockFilterDims.Items[1], "", nil)
+			mockFc.EXPECT().
+				GetFilter(gomock.Any(), gomock.Any()).
+				Return(&filter.GetFilterResponse{}, nil)
+			mockFc.EXPECT().
+				GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(filter.DimensionOptions{}, "", nil)
+
+			mockPc := NewMockPopulationClient(mockCtrl)
+			mockPc.EXPECT().
+				GetAreaTypeParents(gomock.Any(), gomock.Any()).
+				Return(population.GetAreaTypeParentsResponse{}, errors.New("sorry"))
+
+			router := mux.NewRouter()
+			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, mockPc))
 			router.ServeHTTP(w, req)
 
 			Convey("Then the status code should be 500", func() {
@@ -324,6 +376,9 @@ func TestGetCoverageHandler(t *testing.T) {
 				EXPECT().
 				GetAreas(gomock.Any(), gomock.Any()).
 				Return(population.GetAreasResponse{}, errors.New("sorry"))
+			mockPc.EXPECT().
+				GetAreaTypeParents(gomock.Any(), gomock.Any()).
+				Return(population.GetAreaTypeParentsResponse{}, nil)
 
 			router := mux.NewRouter()
 			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, mockPc))
@@ -363,6 +418,9 @@ func TestGetCoverageHandler(t *testing.T) {
 				EXPECT().
 				GetAreas(gomock.Any(), gomock.Any()).
 				Return(population.GetAreasResponse{}, errors.New("sorry"))
+			mockPc.EXPECT().
+				GetAreaTypeParents(gomock.Any(), gomock.Any()).
+				Return(population.GetAreaTypeParentsResponse{}, nil)
 
 			router := mux.NewRouter()
 			router.HandleFunc("/filters/12345/dimensions/geography/coverage", GetCoverage(NewMockRenderClient(mockCtrl), mockFc, mockPc))

--- a/handlers/get_coverage_test.go
+++ b/handlers/get_coverage_test.go
@@ -323,9 +323,6 @@ func TestGetCoverageHandler(t *testing.T) {
 			mockFc.EXPECT().
 				GetFilter(gomock.Any(), gomock.Any()).
 				Return(&filter.GetFilterResponse{}, nil)
-			mockFc.EXPECT().
-				GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(filter.DimensionOptions{}, "", nil)
 
 			mockPc := NewMockPopulationClient(mockCtrl)
 			mockPc.EXPECT().

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -371,6 +371,21 @@ func (m *MockPopulationClient) EXPECT() *MockPopulationClientMockRecorder {
 	return m.recorder
 }
 
+// GetAreaTypeParents mocks base method.
+func (m *MockPopulationClient) GetAreaTypeParents(ctx context.Context, input population.GetAreaTypeParentsInput) (population.GetAreaTypeParentsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAreaTypeParents", ctx, input)
+	ret0, _ := ret[0].(population.GetAreaTypeParentsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAreaTypeParents indicates an expected call of GetAreaTypeParents.
+func (mr *MockPopulationClientMockRecorder) GetAreaTypeParents(ctx, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAreaTypeParents", reflect.TypeOf((*MockPopulationClient)(nil).GetAreaTypeParents), ctx, input)
+}
+
 // GetAreas mocks base method.
 func (m *MockPopulationClient) GetAreas(ctx context.Context, input population.GetAreasInput) (population.GetAreasResponse, error) {
 	m.ctrl.T.Helper()

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -172,7 +172,7 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, fi
 }
 
 // CreateGetCoverage maps data to the coverage model
-func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID, geogName, query, dim string, areas population.GetAreasResponse, opts []model.SelectableElement, isSearch bool) model.Coverage {
+func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterID, geogName, query, dim string, areas population.GetAreasResponse, opts []model.SelectableElement, isSearch bool, parents population.GetAreaTypeParentsResponse) model.Coverage {
 	p := model.Coverage{
 		Page: basePage,
 	}
@@ -206,33 +206,20 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 		ID:    "parent-search",
 		Value: query,
 	}
-	// TODO: Replace dummy data with real list
-	p.ParentSelect = []model.SelectableElement{
-		{
-			Text:       helper.Localise("CoverageSelectDefault", lang, 1),
-			IsSelected: true,
-			IsDisabled: true,
-		},
-		{
-			Text:  "Country",
-			Value: "C",
-		},
-		{
-			Text:  "Region",
-			Value: "R",
-		},
-		{
-			Text:  "Unitary Authority",
-			Value: "UA",
-		},
-		{
-			Text:  "Merged Local Authority",
-			Value: "MLA",
-		},
-		{
-			Text:  "Local Authority",
-			Value: "LA",
-		},
+	if len(parents.AreaTypes) > 1 {
+		p.ParentSelect = []model.SelectableElement{
+			{
+				Text:       helper.Localise("CoverageSelectDefault", lang, 1),
+				IsSelected: true,
+				IsDisabled: true,
+			},
+		}
+	}
+	for _, parent := range parents.AreaTypes {
+		var sel model.SelectableElement
+		sel.Text = parent.Label
+		sel.Value = parent.ID
+		p.ParentSelect = append(p.ParentSelect, sel)
 	}
 
 	var results []model.SelectableElement

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -295,7 +295,17 @@ func TestGetCoverage(t *testing.T) {
 		req := httptest.NewRequest("", "/", nil)
 
 		Convey("When the parameters are valid", func() {
-			coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Country", "", "dim", population.GetAreasResponse{}, []model.SelectableElement{}, false)
+			coverage := CreateGetCoverage(
+				req,
+				coreModel.Page{},
+				lang, "12345",
+				"Country",
+				"",
+				"dim",
+				population.GetAreasResponse{},
+				[]model.SelectableElement{},
+				false,
+				population.GetAreaTypeParentsResponse{})
 			Convey("it sets page metadata", func() {
 				So(coverage.BetaBannerEnabled, ShouldBeTrue)
 				So(coverage.Type, ShouldEqual, "filter-flex-coverage")
@@ -324,8 +334,90 @@ func TestGetCoverage(t *testing.T) {
 			})
 		})
 
+		Convey("When parent types is populated", func() {
+			parents := population.GetAreaTypeParentsResponse{
+				AreaTypes: []population.AreaTypes{
+					{
+						Label: "Area 1",
+						ID:    "id",
+					},
+				},
+			}
+			coverage := CreateGetCoverage(
+				req,
+				coreModel.Page{},
+				lang,
+				"12345",
+				"geography",
+				"",
+				"",
+				population.GetAreasResponse{},
+				[]model.SelectableElement{},
+				false,
+				parents)
+			Convey("Then it maps to the ParentSelect property", func() {
+				So(coverage.ParentSelect[0].Text, ShouldEqual, parents.AreaTypes[0].Label)
+				So(coverage.ParentSelect[0].Value, ShouldEqual, parents.AreaTypes[0].ID)
+				So(coverage.ParentSelect[0].IsDisabled, ShouldBeFalse)
+				So(coverage.ParentSelect[0].IsSelected, ShouldBeFalse)
+			})
+		})
+
+		Convey("When more than one parent type is returned", func() {
+			parents := population.GetAreaTypeParentsResponse{
+				AreaTypes: []population.AreaTypes{
+					{
+						Label: "Area 1",
+						ID:    "id_1",
+					},
+					{
+						Label: "Area 2",
+						ID:    "id_2",
+					},
+				},
+			}
+			coverage := CreateGetCoverage(
+				req,
+				coreModel.Page{},
+				lang,
+				"12345",
+				"geography",
+				"",
+				"",
+				population.GetAreasResponse{},
+				[]model.SelectableElement{},
+				false,
+				parents)
+			Convey("Then it maps the ParentSelect default option", func() {
+				So(coverage.ParentSelect[0].Text, ShouldEqual, "Select")
+				So(coverage.ParentSelect[0].IsDisabled, ShouldBeTrue)
+				So(coverage.ParentSelect[0].IsSelected, ShouldBeTrue)
+			})
+			Convey("Then it maps the ParentSelect properties", func() {
+				So(coverage.ParentSelect[1].Text, ShouldEqual, parents.AreaTypes[0].Label)
+				So(coverage.ParentSelect[1].Value, ShouldEqual, parents.AreaTypes[0].ID)
+				So(coverage.ParentSelect[1].IsDisabled, ShouldBeFalse)
+				So(coverage.ParentSelect[1].IsSelected, ShouldBeFalse)
+				So(coverage.ParentSelect[2].Text, ShouldEqual, parents.AreaTypes[1].Label)
+				So(coverage.ParentSelect[2].Value, ShouldEqual, parents.AreaTypes[1].ID)
+				So(coverage.ParentSelect[2].IsDisabled, ShouldBeFalse)
+				So(coverage.ParentSelect[2].IsSelected, ShouldBeFalse)
+			})
+		})
+
 		Convey("When an unknown geography parameter is given", func() {
-			coverage := CreateGetCoverage(req, coreModel.Page{}, lang, "12345", "Unknown geography", "", "", population.GetAreasResponse{}, []model.SelectableElement{}, false)
+			coverage := CreateGetCoverage(
+				req,
+				coreModel.Page{},
+				lang,
+				"12345",
+				"Unknown geography",
+				"",
+				"",
+				population.GetAreasResponse{},
+				[]model.SelectableElement{},
+				false,
+				population.GetAreaTypeParentsResponse{})
 			Convey("Then it sets the geography to unknown geography", func() {
 				So(coverage.Geography, ShouldEqual, "unknown geography")
 			})
@@ -351,7 +443,8 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				mockedSearchResults,
 				[]model.SelectableElement{},
-				true)
+				true,
+				population.GetAreaTypeParentsResponse{})
 			Convey("Then it sets DisplaySearch property", func() {
 				So(coverage.DisplaySearch, ShouldBeTrue)
 			})
@@ -382,7 +475,8 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				population.GetAreasResponse{},
 				[]model.SelectableElement{},
-				true)
+				true,
+				population.GetAreaTypeParentsResponse{})
 			Convey("Then it sets DisplaySearch property correctly", func() {
 				So(coverage.DisplaySearch, ShouldBeTrue)
 			})
@@ -413,7 +507,8 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				population.GetAreasResponse{},
 				mockedOpt,
-				true)
+				true,
+				population.GetAreaTypeParentsResponse{})
 			Convey("Then it sets DisplaySearch property correctly", func() {
 				So(coverage.DisplaySearch, ShouldBeTrue)
 			})
@@ -448,7 +543,8 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				mockedSearchResults,
 				mockedOpt,
-				true)
+				true,
+				population.GetAreaTypeParentsResponse{})
 			Convey("Then it sets DisplaySearch property correctly", func() {
 				So(coverage.DisplaySearch, ShouldBeTrue)
 			})
@@ -491,7 +587,8 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				mockedSearchResults,
 				mockedOpt,
-				true)
+				true,
+				population.GetAreaTypeParentsResponse{})
 			Convey("Then it sets DisplaySearch property correctly", func() {
 				So(coverage.DisplaySearch, ShouldBeTrue)
 			})


### PR DESCRIPTION
### What

Populating parents area type select list using `pc.GetAreaTypeParents`
✅ **Resolves** trello ticket [As a web user I want to be able to select the type of large area I want to search within](https://trello.com/c/u0onoWcD/5789-as-a-web-user-i-want-to-be-able-to-select-the-type-of-large-area-i-want-to-search-within)

### How to review

- Sense check
- Tests pass
- Media review

#### Single result (no select list)
<img width="588" alt="single parent option" src="https://user-images.githubusercontent.com/19624419/186143365-9122d8c8-93c3-4cbf-919c-243e7e7c33b2.png">

#### More than one result (select list with hint text)
<img width="610" alt="many parents options" src="https://user-images.githubusercontent.com/19624419/186143488-86eb9522-c3b9-4cee-80dd-8d07601660c8.png">

### Who can review

Frontend go dev
