### PR TITLE
Feature/add coverage parent option

### DIFF
--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -6,6 +6,7 @@
             <div class="ons-page__main ons-u-mt-l">
                 <form method="post">
                     <input type="hidden" name="dimension" value="{{- .Dimension -}}">
+                    <input type="hidden" name="geog-id" value="{{- .GeographyID -}}">
                     <fieldset class="ons-fieldset">
                         <legend class="ons-fieldset__legend">{{- localise "CoverageLegend" .Language 1 -}}</legend>
                         <div class="ons-radios__items">
@@ -52,6 +53,9 @@
                                             {{ end }}
                                             {{ if .ParentSearchOutput.HasNoResults }}
                                                 <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
+                                            {{ end }}
+                                            {{ if .ParentSearchOutput.Options }}
+                                                {{ template "partials/coverage/options" .ParentSearchOutput }}
                                             {{ end }}
                                         </div>
                                     </div>

--- a/assets/templates/partials/coverage/results.tmpl
+++ b/assets/templates/partials/coverage/results.tmpl
@@ -8,7 +8,7 @@
                 {{- .Text -}}
                 <button 
                     type="submit" 
-                    name="{{ if .IsSelected }}delete{{ else }}add{{ end }}-option" 
+                    name="{{- .Name -}}" 
                     value="{{- .Value -}}" 
                     class="ons-btn ons-btn--secondary ons-btn--small">
                     <span class="ons-btn__inner">

--- a/handlers/get_coverage.go
+++ b/handlers/get_coverage.go
@@ -70,7 +70,7 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 		return
 	}
 
-	var geogLabel, geogID, dimension string
+	var geogLabel, geogID, dimension, parent string
 	for _, dim := range filterDims.Items {
 		// Needed to determine whether dimension is_area_type
 		// Only one dimension will be is_area_type=true
@@ -84,7 +84,14 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 			geogLabel = filterDimension.Label
 			geogID = filterDimension.ID
 			dimension = filterDimension.Name
+			parent = filterDimension.FilterByParent
+			break
 		}
+	}
+
+	var hasFilterByParent bool
+	if parent != "" {
+		hasFilterByParent = true
 	}
 
 	wg.Add(4)
@@ -147,13 +154,19 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 	}
 
 	options := []model.SelectableElement{}
+	var areaType string
+	if hasFilterByParent {
+		areaType = parent
+	} else {
+		areaType = geogID
+	}
 	for _, opt := range opts.Items {
 		var option model.SelectableElement
 		// TODO: Temporary fix until GetArea endpoint is created
 		areas, err := pc.GetAreas(ctx, population.GetAreasInput{
 			UserAuthToken: accessToken,
 			DatasetID:     filterJob.PopulationType,
-			AreaTypeID:    geogID,
+			AreaTypeID:    areaType,
 			Text:          opt.Option,
 		})
 		if err != nil {
@@ -176,7 +189,7 @@ func getCoverage(w http.ResponseWriter, req *http.Request, rc RenderClient, fc F
 	}
 
 	basePage := rc.NewBasePageModel()
-	m := mapper.CreateGetCoverage(req, basePage, lang, filterID, geogLabel, q, pq, p, c, dimension, areas, options, parents)
+	m := mapper.CreateGetCoverage(req, basePage, lang, filterID, geogLabel, q, pq, p, c, dimension, geogID, areas, options, parents, hasFilterByParent)
 	rc.BuildPage(w, m, "coverage")
 }
 

--- a/handlers/overview.go
+++ b/handlers/overview.go
@@ -143,12 +143,17 @@ func filterFlexOverview(w http.ResponseWriter, req *http.Request, rc RenderClien
 
 			go func(opt filter.DimensionOption) {
 				defer wg.Done()
-
+				var areaTypeID string
+				if dim.FilterByParent != "" {
+					areaTypeID = dim.FilterByParent
+				} else {
+					areaTypeID = dim.ID
+				}
 				// TODO: Temporary fix until GetArea endpoint is created
 				areas, err := pc.GetAreas(ctx, population.GetAreasInput{
 					UserAuthToken: accessToken,
 					DatasetID:     filterJob.PopulationType,
-					AreaTypeID:    dim.ID,
+					AreaTypeID:    areaTypeID,
 					Text:          opt.Option,
 				})
 				if err != nil {
@@ -194,6 +199,7 @@ func filterFlexOverview(w http.ResponseWriter, req *http.Request, rc RenderClien
 				return
 			}
 			dim.IsAreaType = filterDimension.IsAreaType
+			dim.FilterByParent = filterDimension.FilterByParent
 
 			options, err := getOptions(dim)
 			if err != nil {

--- a/handlers/update_coverage_test.go
+++ b/handlers/update_coverage_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	gomock "github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
@@ -25,6 +26,7 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			stubFormData.Add("add-option", "0")
 			stubFormData.Add("coverage", "name-search")
 			stubFormData.Add("larger-area", "country")
+			stubFormData.Add("geog-id", "city")
 
 			Convey("When the user is redirected to the get coverage screen", func() {
 				const filterID = "1234"
@@ -32,8 +34,12 @@ func TestUpdateCoverageHandler(t *testing.T) {
 				filterClient := NewMockFilterClient(mockCtrl)
 				filterClient.
 					EXPECT().
-					AddDimensionValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return("", nil)
+					GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{}, "", nil)
+				filterClient.
+					EXPECT().
+					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Dimension{}, "", nil)
 
 				w := runUpdateCoverage(filterID, "geography", stubFormData, UpdateCoverage(filterClient))
 
@@ -46,12 +52,116 @@ func TestUpdateCoverageHandler(t *testing.T) {
 				})
 			})
 
-			Convey("When the filter API client responds with an error", func() {
+			Convey("When the GetDimensionOptions filter API client responds with an error", func() {
 				filterClient := NewMockFilterClient(mockCtrl)
 				filterClient.
 					EXPECT().
-					AddDimensionValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return("", errors.New("internal error"))
+					GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{}, "", errors.New("internal error"))
+
+				w := runUpdateCoverage("test", "test", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the client should not be redirected", func() {
+					So(w.Header().Get("Location"), ShouldBeEmpty)
+				})
+
+				Convey("And the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+
+			Convey("When the UpdateDimensions filter API client responds with an error", func() {
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{}, "", nil)
+				filterClient.
+					EXPECT().
+					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Dimension{}, "", errors.New("internal error"))
+
+				w := runUpdateCoverage("test", "test", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the client should not be redirected", func() {
+					So(w.Header().Get("Location"), ShouldBeEmpty)
+				})
+
+				Convey("And the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+		})
+
+		Convey("Given a valid add parent option request", func() {
+			stubFormData := url.Values{}
+			stubFormData.Add("dimension", "geography")
+			stubFormData.Add("add-parent-option", "0")
+			stubFormData.Add("coverage", "parent-search")
+			stubFormData.Add("larger-area", "country")
+			stubFormData.Add("geog-id", "city")
+
+			Convey("When the user is redirected to the get coverage screen", func() {
+				const filterID = "1234"
+
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{
+						Items: []filter.DimensionOption{
+							{
+								Option: "Option 1",
+							},
+							{
+								Option: "Option 2",
+							},
+						},
+					}, "", nil)
+				filterClient.
+					EXPECT().
+					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Dimension{}, "", nil)
+
+				w := runUpdateCoverage(filterID, "geography", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the location header should match the get coverage screen", func() {
+					So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/filters/%s/dimensions/geography/coverage", filterID))
+				})
+
+				Convey("And the status code should be 301", func() {
+					So(w.Code, ShouldEqual, http.StatusMovedPermanently)
+				})
+			})
+
+			Convey("When the GetDimensionOptions filter API client responds with an error", func() {
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{}, "", errors.New("internal error"))
+
+				w := runUpdateCoverage("test", "test", stubFormData, UpdateCoverage(filterClient))
+
+				Convey("Then the client should not be redirected", func() {
+					So(w.Header().Get("Location"), ShouldBeEmpty)
+				})
+
+				Convey("And the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+
+			Convey("When the UpdateDimensions filter API client responds with an error", func() {
+				filterClient := NewMockFilterClient(mockCtrl)
+				filterClient.
+					EXPECT().
+					GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{}, "", nil)
+				filterClient.
+					EXPECT().
+					UpdateDimensions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Dimension{}, "", errors.New("internal error"))
 
 				w := runUpdateCoverage("test", "test", stubFormData, UpdateCoverage(filterClient))
 
@@ -71,6 +181,7 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			stubFormData.Add("delete-option", "0")
 			stubFormData.Add("coverage", "name-search")
 			stubFormData.Add("larger-area", "country")
+			stubFormData.Add("geog-id", "city")
 
 			Convey("When the user is redirected to the get coverage screen", func() {
 				const filterID = "1234"
@@ -116,6 +227,7 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			stubFormData.Add("dimension", "geography")
 			stubFormData.Add("coverage", "default")
 			stubFormData.Add("larger-area", "country")
+			stubFormData.Add("geog-id", "city")
 
 			Convey("When the user selects the all geography option", func() {
 				const filterID = "1234"
@@ -163,6 +275,7 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			stubFormData.Add("q", "area")
 			stubFormData.Add("is-search", "true")
 			stubFormData.Add("larger-area", "country")
+			stubFormData.Add("geog-id", "city")
 
 			Convey("When the user is redirected to the get coverage screen", func() {
 				const filterID = "1234"
@@ -187,6 +300,7 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			stubFormData.Add("pq", "area")
 			stubFormData.Add("is-search", "true")
 			stubFormData.Add("larger-area", "country")
+			stubFormData.Add("geog-id", "city")
 
 			Convey("When the user is redirected to the get coverage screen", func() {
 				const filterID = "1234"
@@ -209,6 +323,7 @@ func TestUpdateCoverageHandler(t *testing.T) {
 			stubFormData.Add("dimension", "geography")
 			stubFormData.Add("coverage", "name-search")
 			stubFormData.Add("larger-area", "country")
+			stubFormData.Add("geog-id", "city")
 
 			Convey("When the user makes the request", func() {
 				const filterID = "1234"
@@ -229,10 +344,11 @@ func TestUpdateCoverageHandler(t *testing.T) {
 		Convey("Given an invalid request", func() {
 			Convey("When the request is missing the hidden required form values", func() {
 				tests := map[string]url.Values{
-					"Missing coverage":    {"larger-area": []string{"country"}, "dimension": []string{"geography"}},
+					"Missing coverage":    {"larger-area": []string{"country"}, "dimension": []string{"geography"}, "geog-id": []string{"city"}},
 					"Unknown coverage":    {"coverage": []string{"1234"}, "dimension": []string{"geography"}, "larger-area": []string{"country"}},
-					"Missing larger-area": {"coverage": []string{"default"}, "dimension": []string{"geography"}},
-					"Missing dimension":   {"coverage": []string{"default"}, "larger-area": []string{"country"}},
+					"Missing larger-area": {"coverage": []string{"default"}, "dimension": []string{"geography"}, "geog-id": []string{"city"}},
+					"Missing dimension":   {"coverage": []string{"default"}, "larger-area": []string{"country"}, "geog-id": []string{"city"}},
+					"Missing geog-id":     {"coverage": []string{"default"}, "larger-area": []string{"country"}},
 				}
 
 				for name, formData := range tests {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -306,9 +306,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"",
 				"dim",
+				"geogID",
 				population.GetAreasResponse{},
 				[]model.SelectableElement{},
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("it sets page metadata", func() {
 				So(coverage.BetaBannerEnabled, ShouldBeTrue)
 				So(coverage.Type, ShouldEqual, "filter-flex-coverage")
@@ -329,8 +331,12 @@ func TestGetCoverage(t *testing.T) {
 				So(coverage.ParentSearchOutput.HasNoResults, ShouldBeFalse)
 			})
 
-			Convey("it sets Dimension property", func() {
+			Convey("it sets the Dimension property", func() {
 				So(coverage.Dimension, ShouldEqual, "dim")
+			})
+
+			Convey("it sets the GeographyID property", func() {
+				So(coverage.GeographyID, ShouldEqual, "geogID")
 			})
 		})
 
@@ -354,9 +360,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"",
 				"",
+				"",
 				population.GetAreasResponse{},
 				[]model.SelectableElement{},
-				parents)
+				parents,
+				false)
 			Convey("Then it maps to the ParentSelect property", func() {
 				So(coverage.ParentSelect[0].Text, ShouldEqual, parents.AreaTypes[0].Label)
 				So(coverage.ParentSelect[0].Value, ShouldEqual, parents.AreaTypes[0].ID)
@@ -385,9 +393,11 @@ func TestGetCoverage(t *testing.T) {
 				"id",
 				"",
 				"",
+				"",
 				population.GetAreasResponse{},
 				[]model.SelectableElement{},
-				parents)
+				parents,
+				false)
 			Convey("Then it sets the IsSelected property", func() {
 				So(coverage.ParentSelect[0].IsSelected, ShouldBeTrue)
 			})
@@ -417,9 +427,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"",
 				"",
+				"",
 				population.GetAreasResponse{},
 				[]model.SelectableElement{},
-				parents)
+				parents,
+				false)
 			Convey("Then it maps the ParentSelect default option", func() {
 				So(coverage.ParentSelect[0].Text, ShouldEqual, "Select")
 				So(coverage.ParentSelect[0].IsDisabled, ShouldBeTrue)
@@ -449,9 +461,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"",
 				"",
+				"",
 				population.GetAreasResponse{},
 				[]model.SelectableElement{},
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("Then it sets the geography to unknown geography", func() {
 				So(coverage.Geography, ShouldEqual, "unknown geography")
 			})
@@ -478,9 +492,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"name-search",
 				"",
+				"",
 				mockedSearchResults,
 				[]model.SelectableElement{},
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("Then it sets HasNoResults property", func() {
 				So(coverage.NameSearchOutput.HasNoResults, ShouldBeFalse)
 			})
@@ -490,6 +506,7 @@ func TestGetCoverage(t *testing.T) {
 					{
 						Text:  mockedSearchResults.Areas[0].Label,
 						Value: mockedSearchResults.Areas[0].ID,
+						Name:  "add-option",
 					},
 				}
 				So(coverage.NameSearchOutput.SearchResults, ShouldResemble, expectedResult)
@@ -521,9 +538,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"parent-search",
 				"",
+				"",
 				mockedSearchResults,
 				[]model.SelectableElement{},
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("Then it sets HasNoResults property", func() {
 				So(coverage.ParentSearchOutput.HasNoResults, ShouldBeFalse)
 			})
@@ -533,6 +552,7 @@ func TestGetCoverage(t *testing.T) {
 					{
 						Text:  mockedSearchResults.Areas[0].Label,
 						Value: mockedSearchResults.Areas[0].ID,
+						Name:  "add-parent-option",
 					},
 				}
 				So(coverage.ParentSearchOutput.SearchResults, ShouldResemble, expectedResult)
@@ -555,9 +575,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"name-search",
 				"",
+				"",
 				population.GetAreasResponse{},
 				[]model.SelectableElement{},
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("Then it sets HasNoResults property correctly", func() {
 				So(coverage.NameSearchOutput.HasNoResults, ShouldBeTrue)
 			})
@@ -583,9 +605,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"parent-search",
 				"",
+				"",
 				population.GetAreasResponse{},
 				[]model.SelectableElement{},
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("Then it sets HasNoResults property correctly", func() {
 				So(coverage.ParentSearchOutput.HasNoResults, ShouldBeTrue)
 			})
@@ -604,6 +628,7 @@ func TestGetCoverage(t *testing.T) {
 				{
 					Text:  "label",
 					Value: "0",
+					Name:  "delete-option",
 				},
 			}
 			coverage := CreateGetCoverage(
@@ -617,11 +642,41 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"",
 				"",
+				"",
 				population.GetAreasResponse{},
 				mockedOpt,
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("Then it sets Options property correctly", func() {
 				So(coverage.NameSearchOutput.Options, ShouldResemble, mockedOpt)
+			})
+		})
+
+		Convey("When a parent option is added", func() {
+			mockedOpt := []model.SelectableElement{
+				{
+					Text:  "label",
+					Value: "0",
+				},
+			}
+			coverage := CreateGetCoverage(
+				req,
+				coreModel.Page{},
+				lang,
+				"12345",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				population.GetAreasResponse{},
+				mockedOpt,
+				population.GetAreaTypeParentsResponse{},
+				true)
+			Convey("Then it sets Options property correctly", func() {
+				So(coverage.ParentSearchOutput.Options, ShouldResemble, mockedOpt)
 			})
 		})
 
@@ -651,15 +706,58 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"",
 				"",
+				"",
 				mockedSearchResults,
 				mockedOpt,
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("Then it sets Options property correctly", func() {
 				So(coverage.NameSearchOutput.Options, ShouldResemble, mockedOpt)
 			})
 
 			Convey("Then it sets HasNoResults property", func() {
 				So(coverage.NameSearchOutput.HasNoResults, ShouldBeFalse)
+			})
+		})
+
+		Convey("When an option is added during a parent search", func() {
+			mockedSearchResults := population.GetAreasResponse{
+				Areas: []population.Area{
+					{
+						Label: "parent area one",
+						ID:    "parent area ID",
+					},
+				},
+			}
+			mockedOpt := []model.SelectableElement{
+				{
+					Text:  "label",
+					Value: "0",
+					Name:  "delete-option",
+				},
+			}
+			coverage := CreateGetCoverage(
+				req,
+				coreModel.Page{},
+				lang,
+				"12345",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				mockedSearchResults,
+				mockedOpt,
+				population.GetAreaTypeParentsResponse{},
+				true)
+			Convey("Then it sets Options property correctly", func() {
+				So(coverage.ParentSearchOutput.Options, ShouldResemble, mockedOpt)
+			})
+
+			Convey("Then it sets HasNoResults property", func() {
+				So(coverage.ParentSearchOutput.HasNoResults, ShouldBeFalse)
 			})
 		})
 
@@ -693,9 +791,11 @@ func TestGetCoverage(t *testing.T) {
 				"",
 				"name-search",
 				"",
+				"",
 				mockedSearchResults,
 				mockedOpt,
-				population.GetAreaTypeParentsResponse{})
+				population.GetAreaTypeParentsResponse{},
+				false)
 			Convey("Then it sets Options property correctly", func() {
 				So(coverage.NameSearchOutput.Options, ShouldResemble, mockedOpt)
 			})
@@ -710,14 +810,78 @@ func TestGetCoverage(t *testing.T) {
 						Text:       mockedSearchResults.Areas[0].Label,
 						Value:      mockedSearchResults.Areas[0].ID,
 						IsSelected: true,
+						Name:       "delete-option",
 					},
 					{
 						Text:       mockedSearchResults.Areas[1].Label,
 						Value:      mockedSearchResults.Areas[1].ID,
 						IsSelected: false,
+						Name:       "add-option",
 					},
 				}
 				So(coverage.NameSearchOutput.SearchResults, ShouldResemble, expectedResults)
+			})
+		})
+
+		Convey("When a parent search is performed with one of the parent results already added as an option", func() {
+			mockedSearchResults := population.GetAreasResponse{
+				Areas: []population.Area{
+					{
+						Label: "parent area one",
+						ID:    "0",
+					},
+					{
+						Label: "parent area two",
+						ID:    "1",
+					},
+				},
+			}
+			mockedOpt := []model.SelectableElement{
+				{
+					Text:  "parent area one",
+					Value: "0",
+				},
+			}
+			coverage := CreateGetCoverage(
+				req,
+				coreModel.Page{},
+				lang,
+				"12345",
+				"Unknown geography",
+				"",
+				"",
+				"",
+				"parent-search",
+				"",
+				"",
+				mockedSearchResults,
+				mockedOpt,
+				population.GetAreaTypeParentsResponse{},
+				true)
+			Convey("Then it sets Options property correctly", func() {
+				So(coverage.ParentSearchOutput.Options, ShouldResemble, mockedOpt)
+			})
+
+			Convey("Then it sets HasNoResults property", func() {
+				So(coverage.ParentSearchOutput.HasNoResults, ShouldBeFalse)
+			})
+
+			Convey("Then it maps the search results", func() {
+				expectedResults := []model.SelectableElement{
+					{
+						Text:       mockedSearchResults.Areas[0].Label,
+						Value:      mockedSearchResults.Areas[0].ID,
+						IsSelected: true,
+						Name:       "delete-option",
+					},
+					{
+						Text:       mockedSearchResults.Areas[1].Label,
+						Value:      mockedSearchResults.Areas[1].ID,
+						IsSelected: false,
+						Name:       "add-parent-option",
+					},
+				}
+				So(coverage.ParentSearchOutput.SearchResults, ShouldResemble, expectedResults)
 			})
 		})
 	})

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -9,6 +9,7 @@ type Coverage struct {
 	coreModel.Page
 	Geography          string              `json:"geography"`
 	Dimension          string              `json:"dimension"`
+	GeographyID        string              `json:"geography_id"`
 	ParentSelect       []SelectableElement `json:"parent_select"`
 	NameSearch         SearchField         `json:"name_search"`
 	ParentSearch       SearchField         `json:"parent_search"`
@@ -32,11 +33,13 @@ type SearchOutput struct {
 /* SelectableElement represents the data required for a selectable element.
 Text is the human readable label.
 Value is the value sent to the server.
+Name is the name attribute.
 IsSelected is a boolean representing whether the element is selected.
 IsDisabled is a boolean representing whether the element is disabled */
 type SelectableElement struct {
 	Text       string `json:"text"`
 	Value      string `json:"value"`
+	Name       string `json:"name"`
 	IsSelected bool   `json:"is_selected"`
 	IsDisabled bool   `json:"is_disabled"`
 }


### PR DESCRIPTION
### What

- ✅  [5824 - Add coverage option](https://trello.com/c/4ZyeyvXR/5824-add-a-coverage-option-area-within-a-larger-area)
- ✅  [5825  - Coverage options are added to the Review Changes screen](https://trello.com/c/9HjxEAk8/5825-coverage-options-are-added-to-the-review-changes-screen-area-within-a-larger-area)
- The 'add option' functionality has changed to enable adding a 'parent' or a 'name' option while using the same endpoint. As a consequence of this, an additional GET request is required to ensure the PUT object is reflective of the user's selection to date.

**Note** the area count is incorrect and awaiting backend work to be completed

### How to review

- Sense check
- Tests pass 
- Media review

https://user-images.githubusercontent.com/19624419/187871415-cc46f58f-7748-4f16-a6a2-3036e36ff6db.mov

### Who can review

Frontend go dev
