### PR TITLE
Feature/hide parent coverage search

### DIFF
--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -50,30 +50,32 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <br>
-                                    <div class="ons-radios__item ons-radios__item--no-border ons-u-fw">
-                                        <div class="ons-radio ons-radio--no-border">
-                                            <input type="radio" id="coverage-parent-search" class="ons-radio__input ons-js-radio ons-js-other" value="parent-search" name="coverage" {{ if eq .CoverageType "parent-search" }} checked="checked" {{ end }}>
-                                            <label class="ons-radio__label" for="coverage-parent-search">
-                                                {{- localise "CoverageParentSearch" .Language 1 .Geography -}}
-                                            </label>
-                                            <div class="ons-radio__other ons-u-pb-no">
-                                                {{ template "partials/coverage/select" . }}
-                                                {{ template "partials/coverage/search" .ParentSearch }}
-                                                <div class="ons-u-mt-xs">
-                                                    {{ if .ParentSearchOutput.SearchResults }}
-                                                        {{ template "partials/coverage/results" .ParentSearchOutput }}
-                                                    {{ end }}
-                                                    {{ if .ParentSearchOutput.HasNoResults }}
-                                                        <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
-                                                    {{ end }}
-                                                    {{ if .ParentSearchOutput.Options }}
-                                                        {{ template "partials/coverage/options" .ParentSearchOutput }}
-                                                    {{ end }}
+                                    {{ if .IsSelectParents }}
+                                        <br>
+                                        <div class="ons-radios__item ons-radios__item--no-border ons-u-fw">
+                                            <div class="ons-radio ons-radio--no-border">
+                                                <input type="radio" id="coverage-parent-search" class="ons-radio__input ons-js-radio ons-js-other" value="parent-search" name="coverage" {{ if eq .CoverageType "parent-search" }} checked="checked" {{ end }}>
+                                                <label class="ons-radio__label" for="coverage-parent-search">
+                                                    {{- localise "CoverageParentSearch" .Language 1 .Geography -}}
+                                                </label>
+                                                <div class="ons-radio__other ons-u-pb-no">
+                                                    {{ template "partials/coverage/select" . }}
+                                                    {{ template "partials/coverage/search" .ParentSearch }}
+                                                    <div class="ons-u-mt-xs">
+                                                        {{ if .ParentSearchOutput.SearchResults }}
+                                                            {{ template "partials/coverage/results" .ParentSearchOutput }}
+                                                        {{ end }}
+                                                        {{ if .ParentSearchOutput.HasNoResults }}
+                                                            <div class="ons-u-mt-xs">{{- localise "SearchNoResults" .Language 4 -}}</div>
+                                                        {{ end }}
+                                                        {{ if .ParentSearchOutput.Options }}
+                                                            {{ template "partials/coverage/options" .ParentSearchOutput }}
+                                                        {{ end }}
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
+                                    {{ end }}
                                 </div>
                             </fieldset>
                             {{ if .Page.Error.Title }}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -291,6 +291,8 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 		}
 	}
 
+	p.IsSelectParents = len(parents.AreaTypes) > 0
+
 	return p
 }
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -373,6 +373,32 @@ func TestGetCoverage(t *testing.T) {
 				So(coverage.ParentSelect[0].IsDisabled, ShouldBeFalse)
 				So(coverage.ParentSelect[0].IsSelected, ShouldBeFalse)
 			})
+			Convey("Then it sets the IsSelectParent property", func() {
+				So(coverage.IsSelectParents, ShouldBeTrue)
+			})
+		})
+
+		Convey("When parent types returns an empty list", func() {
+			coverage := CreateGetCoverage(
+				req,
+				coreModel.Page{},
+				lang,
+				"12345",
+				"geography",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+				population.GetAreasResponse{},
+				[]model.SelectableElement{},
+				population.GetAreaTypeParentsResponse{},
+				false,
+				false)
+			Convey("Then it sets the IsSelectParent property", func() {
+				So(coverage.IsSelectParents, ShouldBeFalse)
+			})
 		})
 
 		Convey("When parent type is selected", func() {
@@ -403,6 +429,9 @@ func TestGetCoverage(t *testing.T) {
 				false)
 			Convey("Then it sets the IsSelected property", func() {
 				So(coverage.ParentSelect[0].IsSelected, ShouldBeTrue)
+			})
+			Convey("Then it sets the IsSelectParent property", func() {
+				So(coverage.IsSelectParents, ShouldBeTrue)
 			})
 		})
 
@@ -450,6 +479,9 @@ func TestGetCoverage(t *testing.T) {
 				So(coverage.ParentSelect[2].Value, ShouldEqual, parents.AreaTypes[1].ID)
 				So(coverage.ParentSelect[2].IsDisabled, ShouldBeFalse)
 				So(coverage.ParentSelect[2].IsSelected, ShouldBeFalse)
+			})
+			Convey("Then it sets the IsSelectParent property", func() {
+				So(coverage.IsSelectParents, ShouldBeTrue)
 			})
 		})
 

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -16,6 +16,7 @@ type Coverage struct {
 	CoverageType       string              `json:"coverage_type"`
 	NameSearchOutput   SearchOutput        `json:"name_search_output"`
 	ParentSearchOutput SearchOutput        `json:"parent_search_output"`
+	IsSelectParents    bool                `json:"is_select_parents"`
 }
 
 /* SearchOutput represents the presentable data required to display search output section


### PR DESCRIPTION
### What

Created logic that hides the 'parent coverage' search if the area type chosen is at the top of the hierarchy; manifested by the `parent.AreaTypes` array being empty.

### How to review

- Sense check
- Tests pass

### Who can review

Frontend go dev
