### PR TITLE
Feature/use parent area count

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-flex-dataset
 go 1.18
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.179.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.181.0
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.4.0-beta
 	github.com/ONSdigital/dp-net/v2 v2.5.0-beta

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.179.0 h1:ZPq/heXNEPExdMs51O+V9etVplBx2aJFHsYvQ6xDNvU=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.179.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.181.0 h1:WtxwhQl3+Qp4fN9VIs5tGm9jI8NocFbLQxcVAM6lscM=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.181.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
 github.com/ONSdigital/dp-cookies v0.3.3 h1:KXX4swf+OnljIYbsTYICIBjuRJoxQukGWKBTvBaISlA=
 github.com/ONSdigital/dp-cookies v0.3.3/go.mod h1:qyvkAXoVLMNU9Xf1U5zFGRnuWyLxQ/mHloXUXyzcgb8=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -51,4 +51,5 @@ type PopulationClient interface {
 	GetAreas(ctx context.Context, input population.GetAreasInput) (population.GetAreasResponse, error)
 	GetAreaTypeParents(ctx context.Context, input population.GetAreaTypeParentsInput) (population.GetAreaTypeParentsResponse, error)
 	GetArea(ctx context.Context, input population.GetAreaInput) (population.GetAreaResponse, error)
+	GetParentAreaCount(ctx context.Context, input population.GetParentAreaCountInput) (int, error)
 }

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -416,6 +416,21 @@ func (mr *MockPopulationClientMockRecorder) GetAreas(ctx, input interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAreas", reflect.TypeOf((*MockPopulationClient)(nil).GetAreas), ctx, input)
 }
 
+// GetParentAreaCount mocks base method.
+func (m *MockPopulationClient) GetParentAreaCount(ctx context.Context, input population.GetParentAreaCountInput) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetParentAreaCount", ctx, input)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetParentAreaCount indicates an expected call of GetParentAreaCount.
+func (mr *MockPopulationClientMockRecorder) GetParentAreaCount(ctx, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParentAreaCount", reflect.TypeOf((*MockPopulationClient)(nil).GetParentAreaCount), ctx, input)
+}
+
 // GetPopulationAreaTypes mocks base method.
 func (m *MockPopulationClient) GetPopulationAreaTypes(ctx context.Context, userAuthToken, serviceAuthToken, datasetID string) (population.GetAreaTypesResponse, error) {
 	m.ctrl.T.Helper()

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -36,7 +36,7 @@ const (
 )
 
 // CreateFilterFlexOverview maps data to the Overview model
-func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, path string, queryStrValues []string, filterJob filter.GetFilterResponse, filterDims filter.Dimensions, datasetDims dataset.VersionDimensions, hasNoAreaOptions bool) model.Overview {
+func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, path string, queryStrValues []string, filterJob filter.GetFilterResponse, filterDims []model.FilterDimension, datasetDims dataset.VersionDimensions, hasNoAreaOptions bool) model.Overview {
 	p := model.Overview{
 		Page: basePage,
 	}
@@ -54,11 +54,11 @@ func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, 
 		},
 	}
 
-	for _, dim := range filterDims.Items {
+	for _, dim := range filterDims {
 		pageDim := model.Dimension{}
 		pageDim.Name = dim.Label
 		pageDim.IsAreaType = *dim.IsAreaType
-		pageDim.OptionsCount = len(dim.Options)
+		pageDim.OptionsCount = dim.OptionsCount
 		pageDim.ID = dim.ID
 		pageDim.URI = fmt.Sprintf("%s/%s", path, dim.Name)
 		q := url.Values{}
@@ -98,7 +98,7 @@ func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, 
 	}
 
 	sort.Slice(p.Dimensions, func(i, j int) bool {
-		return p.Dimensions[i].IsAreaType == true
+		return p.Dimensions[i].IsAreaType
 	})
 
 	coverage := []model.Dimension{

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -32,14 +32,17 @@ func TestOverview(t *testing.T) {
 			Version:   1,
 		},
 	}
-	filterDims := filter.Dimensions{
-		Items: []filter.Dimension{
-			{
+	filterDims := []model.FilterDimension{
+		{
+			Dimension: filter.Dimension{
 				Name:       "Dim 1",
 				IsAreaType: helpers.ToBoolPtr(false),
 				Options:    []string{"Opt 1", "Opt 2"},
 			},
-			{
+			OptionsCount: 2,
+		},
+		{
+			Dimension: filter.Dimension{
 				Name:       "Truncated dim 1",
 				IsAreaType: helpers.ToBoolPtr(false),
 				Options: []string{"Opt 1",
@@ -64,7 +67,10 @@ func TestOverview(t *testing.T) {
 					"Opt 20",
 				},
 			},
-			{
+			OptionsCount: 20,
+		},
+		{
+			Dimension: filter.Dimension{
 				Name:       "Truncated dim 2",
 				IsAreaType: helpers.ToBoolPtr(false),
 				Options: []string{"Opt 1",
@@ -81,7 +87,10 @@ func TestOverview(t *testing.T) {
 					"Opt 12",
 				},
 			},
-			{
+			OptionsCount: 12,
+		},
+		{
+			Dimension: filter.Dimension{
 				Name:       "An area dim",
 				IsAreaType: helpers.ToBoolPtr(true),
 				Options: []string{
@@ -96,7 +105,9 @@ func TestOverview(t *testing.T) {
 					"area 9",
 					"area 10",
 				},
-			}},
+			},
+			OptionsCount: 10,
+		},
 	}
 	datasetDims := dataset.VersionDimensions{
 		Items: []dataset.VersionDimension{
@@ -127,35 +138,35 @@ func TestOverview(t *testing.T) {
 			strconv.Itoa(filterJob.Dataset.Version)))
 		So(m.Language, ShouldEqual, lang)
 
-		So(m.Dimensions[0].Name, ShouldEqual, filterDims.Items[3].Label)
+		So(m.Dimensions[0].Name, ShouldEqual, filterDims[3].Label)
 		So(m.Dimensions[0].IsAreaType, ShouldBeTrue)
 		So(m.Dimensions[0].IsCoverage, ShouldBeFalse)
-		So(m.Dimensions[0].Options, ShouldResemble, filterDims.Items[3].Options)
-		So(m.Dimensions[0].OptionsCount, ShouldEqual, 10)
-		So(m.Dimensions[0].ID, ShouldEqual, filterDims.Items[3].ID)
-		So(m.Dimensions[0].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims.Items[3].Name))
+		So(m.Dimensions[0].Options, ShouldResemble, filterDims[3].Options)
+		So(m.Dimensions[0].OptionsCount, ShouldEqual, filterDims[3].OptionsCount)
+		So(m.Dimensions[0].ID, ShouldEqual, filterDims[3].ID)
+		So(m.Dimensions[0].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims[3].Name))
 		So(m.Dimensions[0].IsTruncated, ShouldBeFalse)
 
 		So(m.Dimensions[1].Name, ShouldBeBlank)
 		So(m.Dimensions[1].IsAreaType, ShouldBeFalse)
 		So(m.Dimensions[1].IsCoverage, ShouldBeTrue)
 		So(m.Dimensions[1].IsDefaultCoverage, ShouldBeFalse)
-		So(m.Dimensions[1].Options, ShouldResemble, filterDims.Items[3].Options)
+		So(m.Dimensions[1].Options, ShouldResemble, filterDims[3].Options)
 		So(m.Dimensions[1].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", "geography/coverage"))
 		So(m.Dimensions[1].IsTruncated, ShouldBeFalse)
 
-		So(m.Dimensions[2].Name, ShouldEqual, filterDims.Items[0].Label)
+		So(m.Dimensions[2].Name, ShouldEqual, filterDims[0].Label)
 		So(m.Dimensions[2].IsAreaType, ShouldBeFalse)
 		So(m.Dimensions[2].IsCoverage, ShouldBeFalse)
-		So(m.Dimensions[2].ID, ShouldEqual, filterDims.Items[0].ID)
-		So(m.Dimensions[2].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims.Items[0].Name))
+		So(m.Dimensions[2].ID, ShouldEqual, filterDims[0].ID)
+		So(m.Dimensions[2].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims[0].Name))
 		So(m.Dimensions[2].IsTruncated, ShouldBeFalse)
 
-		So(m.Dimensions[3].Name, ShouldEqual, filterDims.Items[1].Label)
+		So(m.Dimensions[3].Name, ShouldEqual, filterDims[1].Label)
 		So(m.Dimensions[3].IsAreaType, ShouldBeFalse)
 		So(m.Dimensions[3].IsCoverage, ShouldBeFalse)
-		So(m.Dimensions[3].ID, ShouldEqual, filterDims.Items[1].ID)
-		So(m.Dimensions[3].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims.Items[1].Name))
+		So(m.Dimensions[3].ID, ShouldEqual, filterDims[1].ID)
+		So(m.Dimensions[3].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims[1].Name))
 		So(m.Dimensions[3].IsTruncated, ShouldBeTrue)
 
 		So(m.Collapsible.CollapsibleItems[0].Subheading, ShouldEqual, datasetDims.Items[0].Label)
@@ -167,14 +178,14 @@ func TestOverview(t *testing.T) {
 
 	Convey("test truncation maps as expected", t, func() {
 		m := CreateFilterFlexOverview(req, mdl, lang, "", showAll, filterJob, filterDims, datasetDims, false)
-		So(m.Dimensions[3].OptionsCount, ShouldEqual, len(filterDims.Items[1].Options))
+		So(m.Dimensions[3].OptionsCount, ShouldEqual, filterDims[1].OptionsCount)
 		So(m.Dimensions[3].Options, ShouldHaveLength, 9)
 		So(m.Dimensions[3].Options[:3], ShouldResemble, []string{"Opt 1", "Opt 2", "Opt 3"})
 		So(m.Dimensions[3].Options[3:6], ShouldResemble, []string{"Opt 9", "Opt 10", "Opt 11"})
 		So(m.Dimensions[3].Options[6:], ShouldResemble, []string{"Opt 18", "Opt 19", "Opt 20"})
 		So(m.Dimensions[3].IsTruncated, ShouldBeTrue)
 
-		So(m.Dimensions[4].OptionsCount, ShouldEqual, len(filterDims.Items[2].Options))
+		So(m.Dimensions[4].OptionsCount, ShouldEqual, filterDims[2].OptionsCount)
 		So(m.Dimensions[4].Options, ShouldHaveLength, 9)
 		So(m.Dimensions[4].Options[:3], ShouldResemble, []string{"Opt 1", "Opt 2", "Opt 3"})
 		So(m.Dimensions[4].Options[3:6], ShouldResemble, []string{"Opt 5", "Opt 6", "Opt 7"})
@@ -184,7 +195,7 @@ func TestOverview(t *testing.T) {
 
 	Convey("test truncation shows all when parameter given", t, func() {
 		m := CreateFilterFlexOverview(req, mdl, lang, "", []string{"Truncated dim 2"}, filterJob, filterDims, datasetDims, false)
-		So(m.Dimensions[4].OptionsCount, ShouldEqual, len(filterDims.Items[2].Options))
+		So(m.Dimensions[4].OptionsCount, ShouldEqual, filterDims[2].OptionsCount)
 		So(m.Dimensions[4].Options, ShouldHaveLength, 12)
 		So(m.Dimensions[4].IsTruncated, ShouldBeFalse)
 	})

--- a/model/dimesion.go
+++ b/model/dimesion.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/ONSdigital/dp-api-clients-go/v2/filter"
+
 // Dimension represents the data for a single dimension
 type Dimension struct {
 	Options           []string `json:"options"`
@@ -12,4 +14,10 @@ type Dimension struct {
 	IsAreaType        bool     `json:"is_area_type"`
 	IsCoverage        bool     `json:"is_coverage"`
 	IsDefaultCoverage bool     `json:"is_default_coverage"`
+}
+
+// FilterDimension represents a DTO for filter.Dimension with the additional OptionsCount field
+type FilterDimension struct {
+	filter.Dimension
+	OptionsCount int
 }


### PR DESCRIPTION
### What

- Using `pc.GetParentAreaCount` to retrieve the area count for a parent area
- Use the `total_count` field instead of measuring the length of an array
- Replaced `pc.GetAreas` with `pc.GetArea` where necessary
- ✅ Resolves [trello ticket - Fix count on pages that GetArea(s)](https://trello.com/c/cKGTgs1o/5843-fix-count-on-pages-that-getareas)

### How to review

- Sense check
- Tests pass
- Media review

#### 
Image shows when the use add a parent area of `England` the count in brackets equals 2 ✅ 

<img width="752" alt="review screen with parent area count" src="https://user-images.githubusercontent.com/19624419/191767577-b0286e78-db8e-4a34-80eb-256a2aaedaa2.png">

### Who can review

Frontend go dev
