### PR TITLE
feature/separate thousands with a comma

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ generate-prod: fetch-renderer-lib
 .PHONY: fetch-dp-renderer
 fetch-renderer-lib:
 ifeq ($(LOCAL_DP_RENDERER_IN_USE), 1)
-	$(eval CORE_ASSETS_PATH = $(shell grep -w "\"github.com/ONSdigital/dp-renderer\" =>" go.mod | awk -F '=> ' '{print $$2}' | tr -d '"'))
+	$(eval CORE_ASSETS_PATH = $(shell cat go.mod | grep -v "replace" | grep -w "github.com/ONSdigital/dp-renderer" | awk '{print $2}' | tr -d '"'))
 else
-	$(eval APP_RENDERER_VERSION=$(shell grep "github.com/ONSdigital/dp-renderer" go.mod | cut -d ' ' -f2 ))
+	$(eval APP_RENDERER_VERSION=$(shell cat go.mod | grep -v "replace" | grep "github.com/ONSdigital/dp-renderer"  | cut -d ' ' -f2 ))
 	$(eval CORE_ASSETS_PATH = $(shell go get github.com/ONSdigital/dp-renderer@$(APP_RENDERER_VERSION) && go list -f '{{.Dir}}' -m github.com/ONSdigital/dp-renderer))
 endif

--- a/assets/templates/partials/summary.tmpl
+++ b/assets/templates/partials/summary.tmpl
@@ -53,7 +53,7 @@
                                         {{ if .IsDefaultCoverage }}
                                             {{- localise "AreaTypeDefaultCoverage" $lang 1 -}}
                                         {{ else if .IsAreaType }}
-                                            {{- .Name }} ({{ .OptionsCount -}})
+                                            {{- .Name }} ({{ thousandsSeparator .OptionsCount -}})
                                         {{ end }}
                                     {{ else }}
                                         {{ if .Options }}

--- a/assets/templates/selector.tmpl
+++ b/assets/templates/selector.tmpl
@@ -31,7 +31,7 @@
                                     <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
                                 <span class="ons-radio ons-radio--no-border">
                                     <input type="radio" id="{{ .Value }}" class="ons-radio__input ons-js-radio" value="{{ .Value }}" name="dimension" {{ if eq $.InitialSelection .Value }}checked{{ end }}>
-                                    <label class="ons-radio__label" for="{{ .Value }}" id="{{ .Value }}-label">{{ .Label }} ({{ .TotalCount }})</label>
+                                    <label class="ons-radio__label" for="{{ .Value }}" id="{{ .Value }}-label">{{ .Label }} ({{ thousandsSeparator .TotalCount }})</label>
                                 </span>
                             </span>
                                     {{ if notLastItem $length $i }}<br>{{ end }}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.4.0-beta
 	github.com/ONSdigital/dp-net/v2 v2.5.0-beta
-	github.com/ONSdigital/dp-renderer v1.48.0
+	github.com/ONSdigital/dp-renderer v1.51.0
 	github.com/ONSdigital/log.go/v2 v2.3.0-beta
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/ONSdigital/dp-net v1.5.0 h1:H47O5N+eXyXCYqPoQGWwuK12uLds3pCgzxpYwepg+
 github.com/ONSdigital/dp-net v1.5.0/go.mod h1:d/S4n6FJlQwmVIa2rnVt1HnAUgM8XsG0QEJBQp48uGg=
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta h1:be/sM3nEXy5ejU/bvpO/KigUXcfED9o6c+zAh/V2K74=
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta/go.mod h1:QJK9K2N8qwjMS5nZEzxSVALxJ/72KHAFDyFLj/mdLtw=
-github.com/ONSdigital/dp-renderer v1.48.0 h1:bdlCYYY/cSOFLUbyHyr0XA9L0EsKIk9KTeQmKvq7K3I=
-github.com/ONSdigital/dp-renderer v1.48.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
+github.com/ONSdigital/dp-renderer v1.51.0 h1:UVhmDKsancu5Ism54wH83w+JRG3urGWgm7pd5EihTW8=
+github.com/ONSdigital/dp-renderer v1.51.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

- Used template helper function to convert `int` to a `string` with 1000s separated by a comma, as per the [style guide](https://style.ons.gov.uk/category/house-style/numbers/).
- Updated `makefile` to have parity with [dp-frontend-dataset-controller](https://github.com/ONSdigital/dp-frontend-dataset-controller/blob/develop/Makefile)
- ✅ resolves [trello ticket - Display commas to separate thousands in total count displayed to the user](https://trello.com/c/BBxlqgjq/5868-display-commas-to-separate-thousands-in-total-count-displayed-to-the-user)

### How to review

Sense check

### Who can review

Frontend go dev
