### PR TITLE
Feature/adding variable descriptions 

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -184,3 +184,11 @@ one = "Remove"
 description = "Areas added"
 one = "Area added"
 other = "Areas added"
+
+[VariableInfoAreaType]
+description = "Area type variable information"
+one = "<p>Census 2021 statistics are published for a number of different geographies. These can be large, for example the whole of England, or small, for example an output area (OA), the lowest level of geography for which statistics are produced.</p><p>For higher levels of geography, more detailed statistics can be produced. When a lower level of geography is used, such as output areas (which have a minimum of 100 persons), the statistics produced have less detail. This is to protect the confidentiality of people and ensure that individuals or their characteristics cannot be identified.</p>"
+
+[VariableInfoCoverage]
+description = "Coverage variable information"
+one = "<p>Census 2021 statistics are published for the whole of England and Wales. However, you can choose to filter areas by:</p><ul class=\"ons-list\"><li class=\"ons-list__item\">country - for example, Wales</li><li class=\"ons-list__item\">region - for example, London</li><li class=\"ons-list__item\">local authority - for example, Cornwall</li><li class=\"ons-list__item\">health area – for example, Clinical Commissioning Group</li><li class=\"ons-list__item\">statistical area - for example, MSOA or LSOA</li></ul>"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -184,3 +184,11 @@ one = "Remove"
 description = "Areas added"
 one = "Area added"
 other = "Areas added"
+
+[VariableInfoAreaType]
+description = "Area type variable information"
+one = "<p>Census 2021 statistics are published for a number of different geographies. These can be large, for example the whole of England, or small, for example an output area (OA), the lowest level of geography for which statistics are produced.</p><p>For higher levels of geography, more detailed statistics can be produced. When a lower level of geography is used, such as output areas (which have a minimum of 100 persons), the statistics produced have less detail. This is to protect the confidentiality of people and ensure that individuals or their characteristics cannot be identified.</p>"
+
+[VariableInfoCoverage]
+description = "Coverage variable information"
+one = "<p>Census 2021 statistics are published for the whole of England and Wales. However, you can choose to filter areas by:</p><ul class=\"ons-list\"><li class=\"ons-list__item\">country - for example, Wales</li><li class=\"ons-list__item\">region - for example, London</li><li class=\"ons-list__item\">local authority - for example, Cornwall</li><li class=\"ons-list__item\">health area – for example, Clinical Commissioning Group</li><li class=\"ons-list__item\">statistical area - for example, MSOA or LSOA</li></ul>"

--- a/assets/templates/partials/coverage/search.tmpl
+++ b/assets/templates/partials/coverage/search.tmpl
@@ -3,7 +3,7 @@
         <label class="ons-label ons-u-pb-xs" for="{{- .ID -}}">
             {{- localise "CoverageSearchLabel" .Language 1 -}}
         </label>
-        <span class="ons-grid--flex ons-search">
+        <span class="ons-search-component">
             <input 
                 type="search" 
                 id="{{- .ID -}}" 

--- a/assets/templates/partials/summary.tmpl
+++ b/assets/templates/partials/summary.tmpl
@@ -3,19 +3,11 @@
     <h2 class="ons-u-fw-b">{{ localise "Variable" $lang 4 }}</h2>
     <div class="ons-summary ons-summary--hub">
         <div class="ons-summary__group">
-            <table class="ons-summary__items ons-u-mb-s">
-                <thead class="ons-u-vh">
-                    <tr>
-                        <th>{{ localise "Variable" $lang 1 }}</th>
-                        <th>{{ localise "Selection" $lang 1 }}</th>
-                        <th>{{ localise "Change" $lang 1 }}
-                            {{ localise "Selection" $lang 1 }}</th>
-                    </tr>
-                </thead>
+            <div class="ons-summary__items ons-u-mb-s">
                 {{ range $i, $dim := .Dimensions }}
-                    <tbody class="ons-summary__item">
-                        <tr id="{{.ID}}" class="ons-summary__row ons-summary__row--has-values ons-grid--flex@xxs@s ons-grid--between@xxs@s{{ if eq $i 0 }} ons-u-bt{{ end }}{{ if last $i $.Dimensions }} ons-u-bb{{ end }}">
-                            <td class="ons-summary__item-title ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-order--1 ons-u-bb-no@xxs@s ons-u-flex--2@xxs@s">
+                    <div class="ons-summary__item">
+                        <dl id="{{.ID}}" class="ons-summary__row ons-summary__row--has-values ons-grid--flex@xxs@m ons-grid--row@xxs@m ons-u-order--sb@xxs@m{{ if eq $i 0 }} ons-u-bt{{ end }}{{ if last $i $.Dimensions }} ons-u-bb{{ end }}">
+                            <dt class="ons-summary__item-title ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-order--1@xxs@m ons-u-flex--2@xxs@m">
                                 <div class="ons-summary__item--text ons-u-fw-b">
                                     {{ if .IsAreaType }}
                                         {{- localise "AreaTypeDescription" $lang 1 -}}
@@ -25,9 +17,9 @@
                                         {{- .Name -}}
                                     {{ end }}
                                 </div>
-                            </td>
-                            <td class="ons-summary__values ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-pl-no@xxs@s ons-u-order--3 ons-u-fw@xxs@s
-                                    ons-u-pt-no@xxs@s ons-u-bb-no@xxs@s ons-u-d-b@xxs@s">
+                            </dt>
+                            <dd class="ons-summary__values ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-pl-no@xxs@m ons-u-order--3@xxs@m
+                                    ons-u-fw@xxs@m ons-u-pt-no@xxs@m ons-u-pt-no@xxs@m ons-u-bb-no@xxs@m ons-u-d-b@xxs@m">
                                 {{ $length := len .Options }}
                                 {{ $strOptCount := intToString .OptionsCount }}
                                 {{ $isTruncated := .IsTruncated }}
@@ -69,8 +61,8 @@
                                         {{ end }}
                                     {{ end }}
                                 {{ end }}
-                            </td>
-                            <td class="ons-summary__actions ons-u-pt-s ons-u-pb-s ons-u-pl-no@xxs ons-u-ml-xs@xxs ons-u-order--2 ons-u-bb-no@xxs@s">
+                            </dd>
+                            <dd class="ons-summary__actions ons-u-pt-s ons-u-pb-s ons-u-pl-no@xxs ons-u-ml-xs@xxs ons-u-order--2@xxs@m">
                                 {{ if or (.IsAreaType) (.IsCoverage) }}
                                     <a href="{{ .URI }}" class="ons-summary__button">
                                         {{ localise "Change" $lang 1 }}
@@ -83,11 +75,11 @@
                                         </span>
                                     </a>
                                 {{ end }}
-                            </td>
-                        </tr>
-                    </tbody>
+                            </dd>
+                        </dl>
+                    </div>
                 {{ end }}
-            </table>
+            </div>
             {{ if .Collapsible.CollapsibleItems }}
                 {{ template "partials/collapsible" . }}
             {{ end }}

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/80d766d"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/ea0709c"
 	}
 
 	return cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
 				So(cfg.BindAddr, ShouldEqual, "localhost:20100")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/80d766d")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/ea0709c")
 				So(cfg.SupportedLanguages, ShouldResemble, []string{"en", "cy"})
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.4.0-beta
 	github.com/ONSdigital/dp-net/v2 v2.5.0-beta
-	github.com/ONSdigital/dp-renderer v1.51.0
+	github.com/ONSdigital/dp-renderer v1.52.0
 	github.com/ONSdigital/log.go/v2 v2.3.0-beta
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/ONSdigital/dp-net v1.5.0 h1:H47O5N+eXyXCYqPoQGWwuK12uLds3pCgzxpYwepg+
 github.com/ONSdigital/dp-net v1.5.0/go.mod h1:d/S4n6FJlQwmVIa2rnVt1HnAUgM8XsG0QEJBQp48uGg=
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta h1:be/sM3nEXy5ejU/bvpO/KigUXcfED9o6c+zAh/V2K74=
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta/go.mod h1:QJK9K2N8qwjMS5nZEzxSVALxJ/72KHAFDyFLj/mdLtw=
-github.com/ONSdigital/dp-renderer v1.51.0 h1:UVhmDKsancu5Ism54wH83w+JRG3urGWgm7pd5EihTW8=
-github.com/ONSdigital/dp-renderer v1.51.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
+github.com/ONSdigital/dp-renderer v1.52.0 h1:GBVDookTbmpF3V78Z7l9+kFDHBV2dVimkzETN5RARVA=
+github.com/ONSdigital/dp-renderer v1.52.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -25,12 +25,14 @@ import (
 const (
 	queryStrKey           = "showAll"
 	areaTypePrefix        = "AreaType"
+	areaTypeTitle         = "Area type"
 	pluralInt             = 4
 	nameSearch            = "name-search"
 	parentSearch          = "parent-search"
 	nameSearchFieldName   = "q"
 	parentSearchFieldName = "pq"
 	coveragePageType      = "coverage_options"
+	coverageTitle         = "Coverage"
 	areaPageType          = "area_type_options"
 	reviewPageType        = "review_changes"
 )
@@ -113,8 +115,35 @@ func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, 
 	temp := append(coverage, p.Dimensions[1:]...)
 	p.Dimensions = append(p.Dimensions[:1], temp...)
 
+	collapsibleContentItems := mapCollapsible(datasetDims.Items)
+	p.Collapsible = coreModel.Collapsible{
+		Title: coreModel.Localisation{
+			LocaleKey: "VariableExplanation",
+			Plural:    4,
+		},
+		CollapsibleItems: collapsibleContentItems,
+	}
+
+	return p
+}
+
+func mapCollapsible(datasetDims []dataset.VersionDimension) []coreModel.CollapsibleItem {
 	var collapsibleContentItems []coreModel.CollapsibleItem
-	for _, dims := range datasetDims.Items {
+	collapsibleContentItems = append(collapsibleContentItems, coreModel.CollapsibleItem{
+		Subheading: areaTypeTitle,
+		SafeHTML: coreModel.Localisation{
+			LocaleKey: "VariableInfoAreaType",
+			Plural:    1,
+		},
+	})
+	collapsibleContentItems = append(collapsibleContentItems, coreModel.CollapsibleItem{
+		Subheading: coverageTitle,
+		SafeHTML: coreModel.Localisation{
+			LocaleKey: "VariableInfoCoverage",
+			Plural:    1,
+		},
+	})
+	for _, dims := range datasetDims {
 		if dims.Description != "" {
 			var collapsibleContent coreModel.CollapsibleItem
 			collapsibleContent.Subheading = dims.Label
@@ -122,17 +151,7 @@ func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, 
 			collapsibleContentItems = append(collapsibleContentItems, collapsibleContent)
 		}
 	}
-	if len(collapsibleContentItems) > 0 {
-		p.Collapsible = coreModel.Collapsible{
-			Title: coreModel.Localisation{
-				LocaleKey: "VariableExplanation",
-				Plural:    4,
-			},
-			CollapsibleItems: collapsibleContentItems,
-		}
-	}
-
-	return p
+	return collapsibleContentItems
 }
 
 // CreateSelector maps data to the Selector model
@@ -154,7 +173,7 @@ func CreateSelector(req *http.Request, basePage coreModel.Page, dimName, lang, f
 // CreateAreaTypeSelector maps data to the Selector model
 func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, filterID string, areaType []population.AreaType, fDim filter.Dimension, isValidationError bool) model.Selector {
 	p := CreateSelector(req, basePage, fDim.Label, lang, filterID)
-	p.Page.Metadata.Title = "Area type"
+	p.Page.Metadata.Title = areaTypeTitle
 	p.Page.Type = areaPageType
 
 	if isValidationError {
@@ -194,7 +213,7 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 	p := model.Coverage{
 		Page: basePage,
 	}
-	mapCommonProps(req, &p.Page, coveragePageType, "Coverage", lang)
+	mapCommonProps(req, &p.Page, coveragePageType, coverageTitle, lang)
 	p.Breadcrumb = []coreModel.TaxonomyNode{
 		{
 			Title: helper.Localise("Back", lang, 1),

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -169,11 +169,13 @@ func TestOverview(t *testing.T) {
 		So(m.Dimensions[3].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims[1].Name))
 		So(m.Dimensions[3].IsTruncated, ShouldBeTrue)
 
-		So(m.Collapsible.CollapsibleItems[0].Subheading, ShouldEqual, datasetDims.Items[0].Label)
-		So(m.Collapsible.CollapsibleItems[0].Content[0], ShouldEqual, datasetDims.Items[0].Description)
-		So(m.Collapsible.CollapsibleItems[1].Subheading, ShouldEqual, datasetDims.Items[1].Label)
-		So(m.Collapsible.CollapsibleItems[1].Content, ShouldResemble, strings.Split(datasetDims.Items[1].Description, "\n"))
-		So(m.Collapsible.CollapsibleItems, ShouldHaveLength, 2)
+		So(m.Collapsible.CollapsibleItems[0].Subheading, ShouldEqual, "Area type")
+		So(m.Collapsible.CollapsibleItems[1].Subheading, ShouldEqual, "Coverage")
+		So(m.Collapsible.CollapsibleItems[2].Subheading, ShouldEqual, datasetDims.Items[0].Label)
+		So(m.Collapsible.CollapsibleItems[2].Content[0], ShouldEqual, datasetDims.Items[0].Description)
+		So(m.Collapsible.CollapsibleItems[3].Subheading, ShouldEqual, datasetDims.Items[1].Label)
+		So(m.Collapsible.CollapsibleItems[3].Content, ShouldResemble, strings.Split(datasetDims.Items[1].Description, "\n"))
+		So(m.Collapsible.CollapsibleItems, ShouldHaveLength, 4)
 	})
 
 	Convey("test truncation maps as expected", t, func() {


### PR DESCRIPTION
### What

- Adding variable description for `area type` and `coverage`
- Using semantically correct `collapsible` UI component
- Updating `dp-design-system` has resulted in the [hub and spoke](https://ons-design-system.netlify.app/patterns/hub-and-spoke/) pattern needing an update (hence the changes)
- ✅ **Resolves** [trello ticket - Add area type and coverage explanation in variables dropdown](https://trello.com/c/iEbdfiis/5877-add-area-type-and-coverage-explaination-in-variables-dropdown) (for this service) 

### How to review

- Sense check
- Tests pass
- Image check

<img width="681" alt="collapsible with variable information" src="https://user-images.githubusercontent.com/19624419/193257885-0f11a286-6919-4730-82c6-c53861860a37.png">

### Who can review

Frontend go dev
