### PR TITLE
Feature/handle change in option type

### DIFF
--- a/assets/templates/coverage.tmpl
+++ b/assets/templates/coverage.tmpl
@@ -10,6 +10,7 @@
                 <form method="post">
                     <input type="hidden" name="dimension" value="{{- .Dimension -}}">
                     <input type="hidden" name="geog-id" value="{{- .GeographyID -}}">
+                    <input type="hidden" name="option-type" value="{{- .OptionType -}}">
                     {{ if .Page.Error.Title }}
                         <div class="ons-panel ons-panel--error ons-panel--no-title" id="coverage-error">
                             <span class="ons-u-vh">

--- a/handlers/update_coverage.go
+++ b/handlers/update_coverage.go
@@ -90,6 +90,19 @@ func updateCoverage(w http.ResponseWriter, req *http.Request, fc FilterClient, a
 			return
 		}
 
+		if opts.TotalCount > 0 && form.Coverage != form.OptionType {
+			log.Info(ctx, "invalid options combination, removing existing options", log.Data{"filter_id": filterID})
+			_, err := fc.DeleteDimensionOptions(ctx, accessToken, "", collectionID, filterID, form.Dimension)
+			if err != nil {
+				log.Error(ctx, "failed to delete dimension options", err, log.Data{
+					"dimension": form.Dimension,
+				})
+				setStatusCode(req, w, err)
+				return
+			}
+			opts = filter.DimensionOptions{}
+		}
+
 		var options []string
 		for _, opt := range opts.Items {
 			options = append(options, opt.Option)
@@ -136,6 +149,7 @@ type updateCoverageForm struct {
 	LargerArea  string
 	Coverage    string
 	GeographyID string
+	OptionType  string
 }
 
 // parseUpdateCoverageForm parses form data from a http.Request into a updateCoverageForm.
@@ -214,6 +228,8 @@ func parseUpdateCoverageForm(req *http.Request) (updateCoverageForm, error) {
 		value = deleteOption
 	}
 
+	optType := req.FormValue("option-type")
+
 	return updateCoverageForm{
 		Action:      action,
 		Value:       value,
@@ -221,5 +237,6 @@ func parseUpdateCoverageForm(req *http.Request) (updateCoverageForm, error) {
 		LargerArea:  largerArea,
 		Coverage:    coverage,
 		GeographyID: geogID,
+		OptionType:  optType,
 	}, nil
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -284,16 +284,20 @@ func CreateGetCoverage(req *http.Request, basePage coreModel.Page, lang, filterI
 	if len(opts) > 0 && hasFilterByParent {
 		p.CoverageType = parentSearch
 		p.ParentSearchOutput.Options = opts
+		p.OptionType = parentSearch
 	} else if len(opts) > 0 {
 		p.CoverageType = nameSearch
 		p.NameSearchOutput.Options = opts
+		p.OptionType = nameSearch
 	}
 
 	switch coverage {
 	case nameSearch:
+		p.CoverageType = nameSearch
 		p.NameSearchOutput.SearchResults = results
 		p.NameSearchOutput.HasNoResults = len(p.NameSearchOutput.SearchResults) == 0
 	case parentSearch:
+		p.CoverageType = parentSearch
 		p.ParentSearchOutput.SearchResults = results
 		p.ParentSearchOutput.HasNoResults = len(p.ParentSearchOutput.SearchResults) == 0 && !hasValidationErr
 	}

--- a/model/coverage.go
+++ b/model/coverage.go
@@ -17,6 +17,7 @@ type Coverage struct {
 	NameSearchOutput   SearchOutput        `json:"name_search_output"`
 	ParentSearchOutput SearchOutput        `json:"parent_search_output"`
 	IsSelectParents    bool                `json:"is_select_parents"`
+	OptionType         string              `json:"option_type"`
 }
 
 /* SearchOutput represents the presentable data required to display search output section


### PR DESCRIPTION
### What

Handling user change in option type. Currently, a user can add an option from a name search and a parent option. The frontend does (now) error but this is not the cause. The ability to have mixed options is not permitted, however the backend does not (currently) provide any validation for this behaviour. Therefore, the frontend will perform a check on the type of options currently stored and will either allow the user to add an additional option or remove existing options if there is a potential to have mixed option types before adding the user's choice of option(s). 
✅ - Resolves [trello ticket - Search for a different area type to your saved options](https://trello.com/c/wbB7Yh0w/5879-search-for-a-different-area-type-to-your-saved-options)

Notes
- This is a feature, not a bug, as radio buttons are considered mutually exclusive; this feature removes the potential to allow non-permitted option mix
- Backend validation is still required as the removal of a hidden field will easily overcome this check

### How to review

- Sense check
- Tests pass

### Who can review

Frontend go dev
