### PR TITLE
Fix/use flex class to align item

### DIFF
--- a/assets/templates/partials/summary.tmpl
+++ b/assets/templates/partials/summary.tmpl
@@ -62,7 +62,7 @@
                                     {{ end }}
                                 {{ end }}
                             </dd>
-                            <dd class="ons-summary__actions ons-u-pt-s ons-u-pb-s ons-u-pl-no@xxs ons-u-ml-xs@xxs ons-u-order--2@xxs@m">
+                            <dd class="ons-summary__actions ons-u-flex-ai-fs ons-u-pt-s ons-u-pb-s ons-u-pl-no@xxs ons-u-ml-xs@xxs ons-u-order--2@xxs@m">
                                 {{ if or (.IsAreaType) (.IsCoverage) }}
                                     <a href="{{ .URI }}" class="ons-summary__button">
                                         {{ localise "Change" $lang 1 }}


### PR DESCRIPTION
### What

Added css utility class `ons-u-flex-ai-fs` to stop `:focus` filling the container (see images)

### How to review

Sense check

_Before_
<img width="724" alt="highlighting filling container" src="https://user-images.githubusercontent.com/19624419/194353238-a016026d-1089-414b-8099-fe7f0dde5a19.png">

_After_
<img width="724" alt="highlighting link text only" src="https://user-images.githubusercontent.com/19624419/194353434-dbc8e88c-fc34-40fd-9d38-192d1277bf65.png">

### Who can review

Frontend dev
