### PR TITLE
Feature/displaying warning on area type change

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -43,6 +43,14 @@ one = "Filter"
 description = "Continue"
 one = "Continue"
 
+[ImportantInformation]
+description = "Important information"
+one = "Important information"
+
+[ChangeAreaTypeWarning]
+description = "Warning about changing area type"
+one = "Changing the area type will reset the coverage back to the default setting of England and Wales."
+
 [SelectAreaTypeLeadText]
 description = "Select area type"
 one = "Select area type"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -43,6 +43,14 @@ one = "Filter"
 description = "Continue"
 one = "Continue"
 
+[ImportantInformation]
+description = "Important information"
+one = "Important information"
+
+[ChangeAreaTypeWarning]
+description = "Warning about changing area type"
+one = "Changing the area type will reset the coverage back to the default setting of England and Wales."
+
 [SelectAreaTypeLeadText]
 description = "Select area type"
 one = "Select area type"

--- a/assets/templates/selector.tmpl
+++ b/assets/templates/selector.tmpl
@@ -2,15 +2,20 @@
 <div class="ons-page__container ons-container">
     <div class="ons-grid ons-u-ml-no">
         {{ template "partials/breadcrumb" . }}
-
         {{ if .Page.Error.Title }}
             {{ template "partials/error-summary" .Page.Error }}
         {{ end}}
-
         <h1 class="ons-u-fs-xxxl ons-u-mt-s">{{ .Page.Metadata.Title }}</h1>
-
         <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
             <div class="ons-page__main ons-u-mt-l">
+                {{ if .HasOptions }}
+                    <div class="ons-panel ons-panel--info ons-panel--no-title ons-u-mb-l">
+                        <span class="ons-panel__assistive-text ons-u-vh">{{- localise "ImportantInformation" .Language 1 -}}:</span>
+                        <div class="ons-panel__body">
+                            <p>{{- localise "ChangeAreaTypeWarning" .Language 1 -}}</p>
+                        </div>
+                    </div>
+                {{ end }}
                 {{ if .Page.Error.Title }}
                     <div class="ons-panel ons-panel--error ons-panel--no-title" id="area-type-error">
                         <span class="ons-u-vh">{{- localise "Error" .Language 1 -}}:</span>
@@ -18,37 +23,35 @@
                             <p class="ons-panel__error">
                                 <strong>{{ localise "SelectAreaTypeError" .Language 1 }}</strong>
                             </p>
-                {{ end }}
-
-                {{ if gt $length 0 }}
-                    <form method="post">
-                        <fieldset class="ons-fieldset">
-                            <legend class="ons-fieldset__legend ons-u-mb-s">
-                                {{ localise "SelectAreaTypeLeadText" .Language 1 }}
-                            </legend>
-                            <div class="ons-radios__items">
-                                {{ range $i, $selection := .Selections }}
-                                    <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
-                                <span class="ons-radio ons-radio--no-border">
-                                    <input type="radio" id="{{ .Value }}" class="ons-radio__input ons-js-radio" value="{{ .Value }}" name="dimension" {{ if eq $.InitialSelection .Value }}checked{{ end }}>
-                                    <label class="ons-radio__label" for="{{ .Value }}" id="{{ .Value }}-label">{{ .Label }} ({{ thousandsSeparator .TotalCount }})</label>
-                                </span>
-                            </span>
-                                    {{ if notLastItem $length $i }}<br>{{ end }}
-                                {{ end }}
-                            </div>
-                        </fieldset>
-                        <input type="hidden" value="{{ .IsAreaType }}" name="is_area_type">
-                        <button type="submit" class="ons-btn ons-u-mt-s ons-u-mb-s">
-                            <span class="ons-btn__inner">{{ localise "Continue" $.Language 1 }}</span>
-                        </button>
-                    </form>
-                {{ end }}
-
-                {{ if .Error.Title}}
+                        {{ end }}
+                        {{ if gt $length 0 }}
+                            <form method="post">
+                                <fieldset class="ons-fieldset">
+                                    <legend class="ons-fieldset__legend ons-u-mb-s">
+                                        {{ localise "SelectAreaTypeLeadText" .Language 1 }}
+                                    </legend>
+                                    <div class="ons-radios__items">
+                                        {{ range $i, $selection := .Selections }}
+                                            <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
+                                                <span class="ons-radio ons-radio--no-border">
+                                                    <input type="radio" id="{{ .Value }}" class="ons-radio__input ons-js-radio" value="{{ .Value }}" name="dimension" {{ if eq $.InitialSelection .Value }} checked {{ end }}>
+                                                    <label class="ons-radio__label" for="{{ .Value }}" id="{{ .Value }}-label">{{ .Label }} ({{ thousandsSeparator .TotalCount }})</label>
+                                                </span>
+                                            </span>
+                                            {{ if notLastItem $length $i }}<br>{{ end }}
+                                        {{ end }}
+                                    </div>
+                                </fieldset>
+                                <input type="hidden" value="{{ .IsAreaType }}" name="is_area_type">
+                                <button type="submit" class="ons-btn ons-u-mt-s ons-u-mb-s">
+                                    <span class="ons-btn__inner">{{ localise "Continue" $.Language 1 }}</span>
+                                </button>
+                            </form>
+                        {{ end }}
+                        {{ if .Error.Title}}
+                        </div>
                     </div>
                 {{ end }}
-                </div>
             </div>
         </div>
     </div>

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -51,6 +51,16 @@ func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClien
 		return
 	}
 
+	// The total_count is the only field required
+	opts, _, err := fc.GetDimensionOptions(ctx, accessToken, "", collectionID, filterID, dimensionName, &filter.QueryParams{Limit: 0})
+	if err != nil {
+		log.Error(ctx, "failed to get options for dimension", err, logData)
+		setStatusCode(req, w, err)
+		return
+	}
+
+	hasOpts := opts.TotalCount > 0
+
 	areaTypes, err := pc.GetAreaTypes(ctx, population.GetAreaTypesInput{
 		AuthTokens: population.AuthTokens{
 			UserAuthToken: accessToken,
@@ -67,7 +77,7 @@ func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClien
 	}
 
 	isValidationError, _ := strconv.ParseBool(req.URL.Query().Get("error"))
-	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, filterID, areaTypes.AreaTypes, filterDimension, isValidationError)
+	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, filterID, areaTypes.AreaTypes, filterDimension, isValidationError, hasOpts)
 	rc.BuildPage(w, selector, "selector")
 }
 

--- a/handlers/dimensions_test.go
+++ b/handlers/dimensions_test.go
@@ -239,6 +239,11 @@ func TestDimensionsHandler(t *testing.T) {
 						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(stubAreaTypeDimension, "", nil).
 						AnyTimes()
+					mockFilter.
+						EXPECT().
+						GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.DimensionOptions{}, "", nil).
+						AnyTimes()
 
 					mockPc := NewMockPopulationClient(mockCtrl)
 					mockPc.EXPECT().
@@ -297,6 +302,11 @@ func TestDimensionsHandler(t *testing.T) {
 						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(stubAreaTypeDimension, "", nil).
 						AnyTimes()
+					mockFilter.
+						EXPECT().
+						GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.DimensionOptions{}, "", nil).
+						AnyTimes()
 
 					mockPc := NewMockPopulationClient(mockCtrl)
 					mockPc.EXPECT().
@@ -331,6 +341,11 @@ func TestDimensionsHandler(t *testing.T) {
 						EXPECT().
 						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(stubAreaTypeDimension, "", nil).
+						AnyTimes()
+					mockFilter.
+						EXPECT().
+						GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.DimensionOptions{}, "", nil).
 						AnyTimes()
 
 					mockPc := NewMockPopulationClient(mockCtrl)
@@ -370,6 +385,11 @@ func TestDimensionsHandler(t *testing.T) {
 						EXPECT().
 						GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(filter.Dimension{IsAreaType: helpers.ToBoolPtr(true)}, "", nil).
+						AnyTimes()
+					mockFilter.
+						EXPECT().
+						GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(filter.DimensionOptions{}, "", nil).
 						AnyTimes()
 
 					mockPc := NewMockPopulationClient(mockCtrl)
@@ -413,6 +433,11 @@ func TestDimensionsHandler(t *testing.T) {
 					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(stubAreaTypeDimension, "", nil).
 					AnyTimes()
+				mockFilter.
+					EXPECT().
+					GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{}, "", nil).
+					AnyTimes()
 
 				mockPc := NewMockPopulationClient(mockCtrl)
 				mockPc.EXPECT().
@@ -426,6 +451,35 @@ func TestDimensionsHandler(t *testing.T) {
 					AnyTimes()
 
 				w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc))
+
+				Convey("Then the status code should be 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+
+			Convey("When the filter API responds with an error on GetDimensionOptions", func() {
+				mockFilter := NewMockFilterClient(mockCtrl)
+				mockFilter.EXPECT().
+					GetJobState(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.Model{}, "", nil)
+				mockFilter.
+					EXPECT().
+					GetDimension(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(stubAreaTypeDimension, "", nil).
+					AnyTimes()
+				mockFilter.
+					EXPECT().
+					GetDimensionOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{}, "", errors.New("uh oh")).
+					AnyTimes()
+
+				mockRend := NewMockRenderClient(mockCtrl)
+				mockRend.EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain)).
+					AnyTimes()
+
+				w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl)))
 
 				Convey("Then the status code should be 500", func() {
 					So(w.Code, ShouldEqual, http.StatusInternalServerError)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -171,10 +171,11 @@ func CreateSelector(req *http.Request, basePage coreModel.Page, dimName, lang, f
 }
 
 // CreateAreaTypeSelector maps data to the Selector model
-func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, filterID string, areaType []population.AreaType, fDim filter.Dimension, isValidationError bool) model.Selector {
+func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, filterID string, areaType []population.AreaType, fDim filter.Dimension, isValidationError, hasOpts bool) model.Selector {
 	p := CreateSelector(req, basePage, fDim.Label, lang, filterID)
 	p.Page.Metadata.Title = areaTypeTitle
 	p.Page.Type = areaPageType
+	p.HasOptions = hasOpts
 
 	if isValidationError {
 		p.Page.Error = coreModel.Error{

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -251,7 +251,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		}
 
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, false)
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, false, false)
 
 		expectedSelections := []model.Selection{
 			{Value: "one", Label: "One", TotalCount: 1},
@@ -266,7 +266,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 	Convey("Given a valid page", t, func() {
 		const lang = "en"
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, lang, "12345", nil, filter.Dimension{}, false)
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, lang, "12345", nil, filter.Dimension{}, false, false)
 
 		Convey("it sets page metadata", func() {
 			So(changeDimension.BetaBannerEnabled, ShouldBeTrue)
@@ -291,7 +291,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 	Convey("Given the current filter dimension", t, func() {
 		const selectionName = "test"
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{ID: selectionName}, false)
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{ID: selectionName}, false, false)
 
 		Convey("it returns the value as an initial selection", func() {
 			So(changeDimension.InitialSelection, ShouldEqual, selectionName)
@@ -300,10 +300,19 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 
 	Convey("Given a validation error", t, func() {
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, true)
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, true, false)
 
 		Convey("it returns a populated error", func() {
 			So(changeDimension.Error.Title, ShouldNotBeEmpty)
+		})
+	})
+
+	Convey("Given saved options", t, func() {
+		req := httptest.NewRequest("", "/", nil)
+		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, false, true)
+
+		Convey("it returns a warning that saved options will be removed", func() {
+			So(changeDimension.HasOptions, ShouldBeTrue)
 		})
 	})
 }

--- a/model/selector.go
+++ b/model/selector.go
@@ -11,6 +11,7 @@ type Selector struct {
 	Selections       []Selection
 	InitialSelection string
 	IsAreaType       bool
+	HasOptions       bool
 }
 
 // Selection represents a dimension selection (e.g. an Area-type of City)


### PR DESCRIPTION
### What

When `area type` is changed and the coverage has changed from the default (England and Wales) a warning is displayed.
✅ resolves [trello ticket - Warning that coverage resets if you alter area type](https://trello.com/c/mBt08TCX/5892-warning-that-coverage-resets-if-you-alter-area-type)

### How to review

- Sense check
- Tests pass
- Media review

https://user-images.githubusercontent.com/19624419/195831046-582e930b-df7f-4479-bb0a-69f18ad117e2.mov

### Who can review

Frontend go dev
