### PR TITLE
Fix/update PUT dimension object

### DIFF
--- a/handlers/change_dimension.go
+++ b/handlers/change_dimension.go
@@ -42,7 +42,7 @@ func changeDimension(w http.ResponseWriter, req *http.Request, fc FilterClient, 
 	}
 
 	dimension := filter.Dimension{
-		Name:       dimensionName,
+		Name:       form.Dimension,
 		ID:         form.Dimension,
 		IsAreaType: helpers.ToBoolPtr(form.IsAreaType),
 	}

--- a/handlers/change_dimension_test.go
+++ b/handlers/change_dimension_test.go
@@ -53,7 +53,7 @@ func TestChangeDimensionHandler(t *testing.T) {
 				const newDimension = "country"
 
 				expDimension := filter.Dimension{
-					Name:       "geography",
+					Name:       newDimension,
 					ID:         newDimension,
 					IsAreaType: helpers.ToBoolPtr(true),
 				}


### PR DESCRIPTION
### What

`name` and `id` fields should be the same on the PUT dimension object
✅ - resolves [trello ticket - Make dimensionName the same as the dimension id in dp-frontend-filter-flex-dataset](https://trello.com/c/Zgr9Ccli/5908-make-dimensionname-the-same-as-the-dimension-id-in-dp-frontend-filter-flex-dataset)

### How to review

- Sense check
- Tests pass

### Who can review

!me
