### PR TITLE
Fix/remove mapping to collapsible

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -115,43 +115,9 @@ func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, 
 	temp := append(coverage, p.Dimensions[1:]...)
 	p.Dimensions = append(p.Dimensions[:1], temp...)
 
-	collapsibleContentItems := mapCollapsible(datasetDims.Items)
-	p.Collapsible = coreModel.Collapsible{
-		Title: coreModel.Localisation{
-			LocaleKey: "VariableExplanation",
-			Plural:    4,
-		},
-		CollapsibleItems: collapsibleContentItems,
-	}
+	// TODO: Temporarily removing mapping as new endpoints are required to return reliable dataset information
 
 	return p
-}
-
-func mapCollapsible(datasetDims []dataset.VersionDimension) []coreModel.CollapsibleItem {
-	var collapsibleContentItems []coreModel.CollapsibleItem
-	collapsibleContentItems = append(collapsibleContentItems, coreModel.CollapsibleItem{
-		Subheading: areaTypeTitle,
-		SafeHTML: coreModel.Localisation{
-			LocaleKey: "VariableInfoAreaType",
-			Plural:    1,
-		},
-	})
-	collapsibleContentItems = append(collapsibleContentItems, coreModel.CollapsibleItem{
-		Subheading: coverageTitle,
-		SafeHTML: coreModel.Localisation{
-			LocaleKey: "VariableInfoCoverage",
-			Plural:    1,
-		},
-	})
-	for _, dims := range datasetDims {
-		if dims.Description != "" {
-			var collapsibleContent coreModel.CollapsibleItem
-			collapsibleContent.Subheading = dims.Label
-			collapsibleContent.Content = strings.Split(dims.Description, "\n")
-			collapsibleContentItems = append(collapsibleContentItems, collapsibleContent)
-		}
-	}
-	return collapsibleContentItems
 }
 
 // CreateSelector maps data to the Selector model

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
@@ -170,13 +169,7 @@ func TestOverview(t *testing.T) {
 		So(m.Dimensions[3].URI, ShouldEqual, fmt.Sprintf("%s/%s", "", filterDims[1].Name))
 		So(m.Dimensions[3].IsTruncated, ShouldBeTrue)
 
-		So(m.Collapsible.CollapsibleItems[0].Subheading, ShouldEqual, "Area type")
-		So(m.Collapsible.CollapsibleItems[1].Subheading, ShouldEqual, "Coverage")
-		So(m.Collapsible.CollapsibleItems[2].Subheading, ShouldEqual, datasetDims.Items[0].Label)
-		So(m.Collapsible.CollapsibleItems[2].Content[0], ShouldEqual, datasetDims.Items[0].Description)
-		So(m.Collapsible.CollapsibleItems[3].Subheading, ShouldEqual, datasetDims.Items[1].Label)
-		So(m.Collapsible.CollapsibleItems[3].Content, ShouldResemble, strings.Split(datasetDims.Items[1].Description, "\n"))
-		So(m.Collapsible.CollapsibleItems, ShouldHaveLength, 4)
+		// TODO: Removing test coverage until endpoint is created
 	})
 
 	Convey("test truncation maps as expected", t, func() {


### PR DESCRIPTION
### What

As the user progresses through their filter transaction, the dataset information does not update to reflect the variables they have chosen. Therefore the variable descriptions populated within the collapsible become incorrect. More work is required to create an endpoint to reliably return this information.
✅ - **Resolves** trello ticket [Remove variables and dataset information link from custom dataset landing page](https://trello.com/c/bNt3KYAt/5906-remove-variables-and-dataset-information-link-from-custom-dataset-landing-page)

### How to review

Sense check
Tests pass

### Who can review

Frontend dev
