### PR TITLE
fix/valid search returning a 400

### DIFF
--- a/handlers/get_coverage.go
+++ b/handlers/get_coverage.go
@@ -232,6 +232,9 @@ func getAreas(ctx context.Context, cfg *config.Config, pc PopulationClient, acce
 // validatePageNo checks that the given page number is within range and will return a client error if page number is out of range
 func validatePageNo(tc, limit, pageNo int) error {
 	tp := pagination.GetTotalPages(tc, limit)
+	if tc == 0 && pageNo == 1 {
+		return nil
+	}
 	if pageNo > tp {
 		return &clientErr{errors.New("invalid page number")}
 	}


### PR DESCRIPTION
### What

A valid search string was provided and a 400 was being returned; example [link](https://dp.aws.onsdigital.uk/filters/42ac9f21-4f98-4fc0-bebd-15411c3ea455/dimensions/geography/coverage?c=name-search&q=blah)

### How to review

Sense check
Tests pass
_Optionally_ pull this branch and port forward onto the api router and run the same query provided above ⬆️ 

<img width="730" alt="valid search no client error" src="https://user-images.githubusercontent.com/19624419/204807039-e346a6fa-dd95-43e1-91f1-16c7dfae35c7.png">

### Who can review

Frontend go dev