### PR TITLE
Sort area_type by custom order (the wards problem)

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -172,7 +172,7 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, fi
 	}
 
 	sort.Slice(selections, func(i, j int) bool {
-		return selections[i].TotalCount < selections[j].TotalCount
+		return getAreaTypeIsLessThan(selections[i], selections[j])
 	})
 	if lowest_geography != "" {
 		var filtered_selections []model.Selection
@@ -196,6 +196,33 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, fi
 	p.ReleaseDate = releaseDate
 
 	return p
+}
+
+func getAreaTypeIsLessThan(left, right model.Selection) bool {
+	order := map[string]int{
+		"nat":  100,
+		"ctry": 200,
+		"rgn":  300,
+		"utla": 400,
+		"ltla": 500,
+		"wd":   600,
+		"msoa": 700,
+		"lsoa": 800,
+		"oa":   900,
+	}
+	leftVal, leftOk := order[left.Value]
+	rightVal, rightOk := order[right.Value]
+
+	if leftOk && rightOk {
+		return leftVal < rightVal
+	}
+	if leftOk {
+		return true
+	}
+	if rightOk {
+		return false
+	}
+	return left.TotalCount < right.TotalCount
 }
 
 // CreateGetCoverage maps data to the coverage model


### PR DESCRIPTION
### What

This PR allows radios on the area-types screen to be sorted by a hardcoded sort order

The list of area types is currently sorted by count of area type. When wards arrive they will need to appear in this list above MSOAs although there are more of them.

Defaults to sorting by TotalCount if area-types are not in the hardcoded order - this prevents breakage on sample datasets that use different area codes to the live data

Note: Lowest level of geography works on the basis of position in the sorted list. If lowest level of geography is defined as MSOA the area type list will include the list down to MSOA including Ward. We believe this to be the desired behaviour

------

Image data doesn't include wards so this demo moves LSOA above LTLAs in the hierarchy and sets the lowest geography as LTLA

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/6823289/207883486-c11b4d4f-93d0-49c4-aec8-d8751f57d7c0.png">

### How to review

* sense check
* tests pass

### Who can review

!me
