### PR TITLE
Feature/custom sort env config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	Debug                       bool          `envconfig:"DEBUG"`
 	EnableMultivariate          bool          `envconfig:"ENABLE_MULTIVARIATE"`
+	EnableCustomSort            bool          `envconfig:"ENABLE_CUSTOM_SORT"`
 	BindAddr                    string        `envconfig:"BIND_ADDR"`
 	APIRouterURL                string        `envconfig:"API_ROUTER_URL"`
 	DefaultMaximumSearchResults int           `envconfig:"DEFAULT_MAXIMUM_SEARCH_RESULTS"`
@@ -48,6 +49,7 @@ func get() (*Config, error) {
 	cfg = &Config{
 		Debug:                       false,
 		EnableMultivariate:          false,
+		EnableCustomSort:            false,
 		BindAddr:                    "localhost:20100",
 		APIRouterURL:                "http://localhost:23200/v1",
 		DefaultMaximumSearchResults: 50,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,7 @@ func TestConfig(t *testing.T) {
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.EnableMultivariate, ShouldBeFalse)
+				So(cfg.EnableCustomSort, ShouldBeFalse)
 				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
 				So(cfg.BindAddr, ShouldEqual, "localhost:20100")
 				So(cfg.DefaultMaximumSearchResults, ShouldEqual, 50)

--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
+	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/config"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mapper"
 	"github.com/ONSdigital/dp-net/v2/handlers"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -13,13 +14,13 @@ import (
 )
 
 // DimensionsSelector Handler
-func DimensionsSelector(rc RenderClient, fc FilterClient, pc PopulationClient, dc DatasetClient) http.HandlerFunc {
+func DimensionsSelector(rc RenderClient, fc FilterClient, pc PopulationClient, dc DatasetClient, cfg config.Config) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
-		dimensionsSelector(w, req, rc, fc, pc, dc, collectionID, accessToken, lang)
+		dimensionsSelector(w, req, cfg, rc, fc, pc, dc, collectionID, accessToken, lang)
 	})
 }
 
-func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClient, fc FilterClient, pc PopulationClient, dc DatasetClient, collectionID, accessToken, lang string) {
+func dimensionsSelector(w http.ResponseWriter, req *http.Request, cfg config.Config, rc RenderClient, fc FilterClient, pc PopulationClient, dc DatasetClient, collectionID, accessToken, lang string) {
 	ctx := req.Context()
 	vars := mux.Vars(req)
 	filterID := vars["filterID"]
@@ -107,7 +108,7 @@ func dimensionsSelector(w http.ResponseWriter, req *http.Request, rc RenderClien
 	}
 
 	isValidationError, _ := strconv.ParseBool(req.URL.Query().Get("error"))
-	selector := mapper.CreateAreaTypeSelector(req, basePage, lang, filterID, areaTypes.AreaTypes, filterDimension, details.LowestGeography, releaseDate, dataset, isValidationError, hasOpts)
+	selector := mapper.CreateAreaTypeSelector(req, cfg.EnableCustomSort, basePage, lang, filterID, areaTypes.AreaTypes, filterDimension, details.LowestGeography, releaseDate, dataset, isValidationError, hasOpts)
 	rc.BuildPage(w, selector, "selector")
 }
 

--- a/handlers/dimensions_test.go
+++ b/handlers/dimensions_test.go
@@ -71,7 +71,7 @@ func TestDimensionsHandler(t *testing.T) {
 
 				w := runDimensionsSelector(
 					"number+of+siblings",
-					DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc),
+					DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc, cfg),
 				)
 
 				Convey("And the status code should be 200", func() {
@@ -102,7 +102,7 @@ func TestDimensionsHandler(t *testing.T) {
 
 			w := runDimensionsSelector(
 				"city",
-				DimensionsSelector(NewMockRenderClient(mockCtrl), mockFilter, NewMockPopulationClient(mockCtrl), mockDc),
+				DimensionsSelector(NewMockRenderClient(mockCtrl), mockFilter, NewMockPopulationClient(mockCtrl), mockDc, cfg),
 			)
 
 			Convey("Then the status code should be 404", func() {
@@ -154,7 +154,7 @@ func TestDimensionsHandler(t *testing.T) {
 
 				w := runDimensionsSelector(
 					dimensionName,
-					DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc),
+					DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc, cfg),
 				)
 
 				Convey("And the status code should be 200", func() {
@@ -197,7 +197,7 @@ func TestDimensionsHandler(t *testing.T) {
 
 				w := runDimensionsSelector(
 					dimensionName,
-					DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc),
+					DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc, cfg),
 				)
 
 				Convey("And the status code should be 200", func() {
@@ -239,7 +239,7 @@ func TestDimensionsHandler(t *testing.T) {
 
 				w := runDimensionsSelector(
 					dimensionName,
-					DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc),
+					DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc, cfg),
 				)
 
 				Convey("And the status code should be 200", func() {
@@ -264,7 +264,7 @@ func TestDimensionsHandler(t *testing.T) {
 
 				w := runDimensionsSelector(
 					dimensionName,
-					DimensionsSelector(NewMockRenderClient(mockCtrl), mockFilter, NewMockPopulationClient(mockCtrl), mockDc),
+					DimensionsSelector(NewMockRenderClient(mockCtrl), mockFilter, NewMockPopulationClient(mockCtrl), mockDc, cfg),
 				)
 
 				Convey("Then the status code should be 500", func() {
@@ -374,7 +374,7 @@ func TestDimensionsHandler(t *testing.T) {
 						}, nil).
 						AnyTimes()
 
-					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc))
+					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc, cfg))
 
 					Convey("And the status code should be 200", func() {
 						So(w.Code, ShouldEqual, http.StatusOK)
@@ -470,7 +470,7 @@ func TestDimensionsHandler(t *testing.T) {
 						}, nil).
 						AnyTimes()
 
-					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc))
+					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc, cfg))
 
 					Convey("And the status code should be 200", func() {
 						So(w.Code, ShouldEqual, http.StatusOK)
@@ -525,7 +525,7 @@ func TestDimensionsHandler(t *testing.T) {
 						}, nil).
 						AnyTimes()
 
-					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc))
+					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc, cfg))
 
 					Convey("And the status code should be 200", func() {
 						So(w.Code, ShouldEqual, http.StatusOK)
@@ -578,7 +578,7 @@ func TestDimensionsHandler(t *testing.T) {
 						}, nil).
 						AnyTimes()
 
-					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc))
+					w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc, cfg))
 
 					Convey("And the status code should be 200", func() {
 						So(w.Code, ShouldEqual, http.StatusOK)
@@ -637,7 +637,7 @@ func TestDimensionsHandler(t *testing.T) {
 						}, nil).
 						AnyTimes()
 
-					selector := DimensionsSelector(mockRend, mockFilter, mockPc, mockDc)
+					selector := DimensionsSelector(mockRend, mockFilter, mockPc, mockDc, cfg)
 
 					w := httptest.NewRecorder()
 					router := mux.NewRouter()
@@ -690,7 +690,7 @@ func TestDimensionsHandler(t *testing.T) {
 					}, nil).
 					AnyTimes()
 
-				w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc))
+				w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, mockPc, mockDc, cfg))
 
 				Convey("Then the status code should be 500", func() {
 					So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -732,7 +732,7 @@ func TestDimensionsHandler(t *testing.T) {
 					}, nil).
 					AnyTimes()
 
-				w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc))
+				w := runDimensionsSelector(dimensionName, DimensionsSelector(mockRend, mockFilter, NewMockPopulationClient(mockCtrl), mockDc, cfg))
 
 				Convey("Then the status code should be 500", func() {
 					So(w.Code, ShouldEqual, http.StatusInternalServerError)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -139,7 +139,7 @@ func CreateSelector(req *http.Request, basePage coreModel.Page, dimName, lang, f
 }
 
 // CreateAreaTypeSelector maps data to the Selector model
-func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, filterID string, areaType []population.AreaType, fDim filter.Dimension, lowest_geography, releaseDate string, dataset dataset.DatasetDetails, isValidationError, hasOpts bool) model.Selector {
+func CreateAreaTypeSelector(req *http.Request, enableCustomSort bool, basePage coreModel.Page, lang, filterID string, areaType []population.AreaType, fDim filter.Dimension, lowest_geography, releaseDate string, dataset dataset.DatasetDetails, isValidationError, hasOpts bool) model.Selector {
 	p := CreateSelector(req, basePage, fDim.Label, lang, filterID)
 	p.Page.Metadata.Title = areaTypeTitle
 	p.Page.Type = areaPageType
@@ -172,7 +172,11 @@ func CreateAreaTypeSelector(req *http.Request, basePage coreModel.Page, lang, fi
 	}
 
 	sort.Slice(selections, func(i, j int) bool {
-		return getAreaTypeIsLessThan(selections[i], selections[j])
+		if enableCustomSort {
+			return getAreaTypeIsLessThan(selections[i], selections[j])
+		} else {
+			return selections[i].TotalCount < selections[j].TotalCount
+		}
 	})
 	if lowest_geography != "" {
 		var filtered_selections []model.Selection

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -246,7 +246,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		}
 
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
+		changeDimension := CreateAreaTypeSelector(req, false, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
 
 		expectedSelections := []model.Selection{
 			{Value: "one", Label: "One", Description: "One description", TotalCount: 1},
@@ -267,7 +267,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		}
 
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
+		changeDimension := CreateAreaTypeSelector(req, false, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
 
 		expectedSelections := []model.Selection{
 			{Value: "nat", Label: "Nation", TotalCount: 1},
@@ -290,7 +290,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		}
 
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
+		changeDimension := CreateAreaTypeSelector(req, true, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
 
 		Convey("Sorts selections ascending by standard order", func() {
 			expectedSelections := []model.Selection{
@@ -312,7 +312,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		}
 
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
+		changeDimension := CreateAreaTypeSelector(req, false, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
 
 		Convey("Sorts known items by order then unknown items by TotalCount", func() {
 			expectedSelections := []model.Selection{
@@ -336,7 +336,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		}
 
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
+		changeDimension := CreateAreaTypeSelector(req, true, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
 
 		Convey("Sorts selections ascending by TotalCount", func() {
 			expectedSelections := []model.Selection{
@@ -362,7 +362,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		lowest_geography := "rgn"
 
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, lowest_geography, "", dataset.DatasetDetails{}, false, false)
+		changeDimension := CreateAreaTypeSelector(req, true, coreModel.Page{}, "en", "12345", areas, filter.Dimension{}, lowest_geography, "", dataset.DatasetDetails{}, false, false)
 
 		Convey("Returns the sorted selections stopping at the lowest_level", func() {
 			expectedSelections := []model.Selection{
@@ -378,7 +378,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 	Convey("Given a valid page", t, func() {
 		const lang = "en"
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, lang, "12345", nil, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
+		changeDimension := CreateAreaTypeSelector(req, false, coreModel.Page{}, lang, "12345", nil, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, false)
 
 		Convey("it sets page metadata", func() {
 			So(changeDimension.BetaBannerEnabled, ShouldBeTrue)
@@ -403,7 +403,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 	Convey("Given the current filter dimension", t, func() {
 		const selectionName = "test"
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{ID: selectionName}, "", "", dataset.DatasetDetails{}, false, false)
+		changeDimension := CreateAreaTypeSelector(req, false, coreModel.Page{}, "en", "12345", nil, filter.Dimension{ID: selectionName}, "", "", dataset.DatasetDetails{}, false, false)
 
 		Convey("it returns the value as an initial selection", func() {
 			So(changeDimension.InitialSelection, ShouldEqual, selectionName)
@@ -412,7 +412,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 
 	Convey("Given a validation error", t, func() {
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, "", "", dataset.DatasetDetails{}, true, false)
+		changeDimension := CreateAreaTypeSelector(req, false, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, "", "", dataset.DatasetDetails{}, true, false)
 
 		Convey("it returns a populated error", func() {
 			So(changeDimension.Error.Title, ShouldNotBeEmpty)
@@ -421,7 +421,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 
 	Convey("Given saved options", t, func() {
 		req := httptest.NewRequest("", "/", nil)
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, true)
+		changeDimension := CreateAreaTypeSelector(req, false, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, "", "", dataset.DatasetDetails{}, false, true)
 
 		Convey("it returns a warning that saved options will be removed", func() {
 			So(changeDimension.HasOptions, ShouldBeTrue)
@@ -432,7 +432,7 @@ func TestCreateAreaTypeSelector(t *testing.T) {
 		req := httptest.NewRequest("", "/", nil)
 		releaseDate := "2022/11/29"
 		dataset := dataset.DatasetDetails{ID: "dataset-id", Title: "Dataset title"}
-		changeDimension := CreateAreaTypeSelector(req, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, "", releaseDate, dataset, false, true)
+		changeDimension := CreateAreaTypeSelector(req, false, coreModel.Page{}, "en", "12345", nil, filter.Dimension{}, "", releaseDate, dataset, false, true)
 
 		Convey("it sets DatasetID, DatasetTitle and ReleaseData", func() {
 			So(changeDimension.DatasetId, ShouldEqual, dataset.ID)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -38,7 +38,7 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 		r.StrictSlash(true).Path("/filters/{filterID}/dimensions/change").Methods("GET").HandlerFunc(handlers.GetChangeDimensions(c.Render, c.Filter, c.Dataset, c.Population))
 		r.StrictSlash(true).Path("/filters/{filterID}/dimensions/change").Methods("POST").HandlerFunc(handlers.PostChangeDimensions(c.Filter))
 	}
-	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(handlers.DimensionsSelector(c.Render, c.Filter, c.Population, c.Dataset))
+	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("GET").HandlerFunc(handlers.DimensionsSelector(c.Render, c.Filter, c.Population, c.Dataset, *cfg))
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/{name}").Methods("POST").HandlerFunc(handlers.ChangeDimension(c.Filter))
 
 	r.StrictSlash(true).Path("/filters/{filterID}/dimensions/geography/coverage").Methods("GET").HandlerFunc(handlers.GetCoverage(c.Render, c.Filter, c.Population, c.Dataset, *cfg))


### PR DESCRIPTION
### What

Put the [custom sort](https://github.com/ONSdigital/dp-frontend-filter-flex-dataset/commit/0bdd138324df752197142290bcba5c6a9a6f78cf) of area types behind a feature toggle to enable production releases

### How to review

- Sense check
- Tests pass
- Image check

#### Custom sort disabled
<img width="517" alt="custom sort disabled" src="https://user-images.githubusercontent.com/19624419/209808077-ae481734-8dee-4d7e-8c7c-cfd3eddb3bd7.png">

#### Custom sort enabled
<img width="517" alt="custom sort enabled" src="https://user-images.githubusercontent.com/19624419/209808180-d12e99f3-7d41-40b2-b349-932617fe2620.png">

N.B. Coming soon! A PR with the environment settings...

### Who can review

Frontend go dev
