### PR TITLE
sort options using option code

### DIFF
--- a/handlers/overview_test.go
+++ b/handlers/overview_test.go
@@ -757,4 +757,122 @@ func TestOverviewHandler(t *testing.T) {
 			// })
 		})
 	})
+
+	Convey("Dimension options are sorted", t, func() {
+		getOptionList := func(items []dataset.Option) []string {
+			results := []string{}
+			for _, item := range items {
+				results = append(results, item.Option)
+			}
+			return results
+		}
+
+		Convey("given non-numeric options", func() {
+			nonNumeric := []dataset.Option{
+				{
+					DimensionID: "dim_2",
+					Option:      "option 2",
+				},
+				{
+					DimensionID: "dim_1",
+					Option:      "option 1",
+				},
+			}
+			Convey("when they are sorted", func() {
+				sorted := sortOptionsByCode(nonNumeric)
+
+				Convey("then options are sorted alphabetically", func() {
+					actual := getOptionList(sorted)
+					expected := []string{"option 1", "option 2"}
+					So(actual, ShouldResemble, expected)
+				})
+			})
+		})
+
+		Convey("given simple numeric options", func() {
+			nonNumeric := []dataset.Option{
+				{
+					DimensionID: "dim_2",
+					Option:      "2",
+				},
+				{
+					DimensionID: "dim_10",
+					Option:      "10",
+				},
+				{
+					DimensionID: "dim_1",
+					Option:      "1",
+				},
+			}
+			Convey("when they are sorted", func() {
+				sorted := sortOptionsByCode(nonNumeric)
+
+				Convey("then options are sorted numerically", func() {
+					actual := getOptionList(sorted)
+					expected := []string{"1", "2", "10"}
+					So(actual, ShouldResemble, expected)
+				})
+			})
+		})
+
+		Convey("given numeric options with negatives", func() {
+			nonNumeric := []dataset.Option{
+				{
+					DimensionID: "dim_2",
+					Option:      "2",
+				},
+				{
+					DimensionID: "dim_-1",
+					Option:      "-1",
+				},
+				{
+					DimensionID: "dim_10",
+					Option:      "10",
+				},
+				{
+					DimensionID: "dim_-10",
+					Option:      "-10",
+				},
+				{
+					DimensionID: "dim_1",
+					Option:      "1",
+				},
+			}
+			Convey("when they are sorted", func() {
+				sorted := sortOptionsByCode(nonNumeric)
+
+				Convey("then options are sorted numerically with negatives at the end", func() {
+					actual := getOptionList(sorted)
+					expected := []string{"1", "2", "10", "-1", "-10"}
+					So(actual, ShouldResemble, expected)
+				})
+			})
+		})
+
+		Convey("given mixed numeric and non-numeric options", func() {
+			nonNumeric := []dataset.Option{
+				{
+					DimensionID: "dim_2",
+					Option:      "2nd Option",
+				},
+				{
+					DimensionID: "dim_1",
+					Option:      "1",
+				},
+				{
+					DimensionID: "dim_10",
+					Option:      "10",
+				},
+			}
+			Convey("when they are sorted", func() {
+				sorted := sortOptionsByCode(nonNumeric)
+
+				Convey("then options are sorted alphanumerically", func() {
+					actual := getOptionList(sorted)
+					expected := []string{"1", "10", "2nd Option"}
+					So(actual, ShouldResemble, expected)
+				})
+			})
+		})
+	})
 }


### PR DESCRIPTION
### What
Sort dimension options ascending using their code rather than label
If codes - which are stored as strings - are all numeric then sort numerically ascending with negative codes at the end

This allows for complex ordering as with Ethnicity or, as in the case below, the ability to sort "Other" options to the end

<img width="953" alt="image" src="https://user-images.githubusercontent.com/6823289/210960182-5943e9d8-19ea-4907-8be4-bedf22a8126b.png">

### How to review

Code review
Media check
Tests pass

### Who can review

FE Go Dev
