### PR TITLE
5983 Remove categories count from label

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -62,7 +62,7 @@ func CreateFilterFlexOverview(req *http.Request, basePage coreModel.Page, lang, 
 
 	for _, dim := range filterDims {
 		pageDim := model.Dimension{}
-		pageDim.Name = dim.Label
+		pageDim.Name = cleanDimensionLabel(dim.Label)
 		pageDim.IsAreaType = *dim.IsAreaType
 		pageDim.OptionsCount = dim.OptionsCount
 		pageDim.ID = dim.ID

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -414,7 +415,7 @@ func CreateGetChangeDimensions(req *http.Request, basePage coreModel.Page, lang,
 	for _, dim := range dims {
 		if !*dim.IsAreaType {
 			selections = append(selections, model.SelectableElement{
-				Text:  dim.Label,
+				Text:  cleanDimensionLabel(dim.Label),
 				Value: dim.ID,
 				Name:  "delete-option",
 			})
@@ -446,7 +447,7 @@ func mapDimensionsResponse(pDims population.GetDimensionsResponse, selections *[
 	for _, pDim := range pDims.Dimensions {
 		var sel model.SelectableElement
 		sel.Name = "add-dimension"
-		sel.Text = pDim.Label
+		sel.Text = cleanDimensionLabel(pDim.Label)
 		sel.InnerText = pDim.Description
 		sel.Value = pDim.ID
 		pDimId := helpers.TrimCategoryValue(pDim.ID)
@@ -465,6 +466,13 @@ func mapDimensionsResponse(pDims population.GetDimensionsResponse, selections *[
 		return results[i].Text < results[j].Text
 	})
 	return results
+}
+
+// cleanDimensionlabel is a helper function that parses dimension labels from cantabular into display text
+func cleanDimensionLabel(label string) string {
+	matcher := regexp.MustCompile(`(\(\d+ ((C|c)ategories|(C|c)ategory)\))`)
+	result := matcher.ReplaceAllString(label, "")
+	return strings.TrimSpace(result)
 }
 
 // getAddOptionStr is a helper function to determine which add option string should be returned

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -210,6 +210,21 @@ func TestOverview(t *testing.T) {
 		So(m.Dimensions[1].IsCoverage, ShouldBeTrue)
 	})
 
+	Convey("test filter dims format labels using cleanDimensionLabel", t, func() {
+		newFilterDims := append([]model.FilterDimension{}, filterDims...)
+		newFilterDims = append(newFilterDims, []model.FilterDimension{
+			{
+				Dimension: filter.Dimension{
+					Label:      "Example (21 categories)",
+					IsAreaType: helpers.ToBoolPtr(false),
+				},
+			},
+		}...)
+
+		m := CreateFilterFlexOverview(req, mdl, lang, "", showAll, filterJob, newFilterDims, datasetDims, false, false, zebedee.EmergencyBanner{}, "")
+		So(m.Dimensions[5].Name, ShouldEqual, "Example")
+	})
+
 	Convey("given hasNoAreaOptions parameter", t, func() {
 		Convey("when parameter is true", func() {
 			m := CreateFilterFlexOverview(req, mdl, lang, "", []string{""}, filterJob, filterDims, datasetDims, true, false, zebedee.EmergencyBanner{}, "")
@@ -1719,12 +1734,12 @@ func TestGetChangeDimensions(t *testing.T) {
 				Dimensions: []population.Dimension{
 					{
 						ID:          "dim-1",
-						Label:       "dim one",
+						Label:       "dim one (100 categories)",
 						Description: "description one",
 					},
 					{
 						ID:          "dim-a",
-						Label:       "dim a",
+						Label:       "dim a (1 category)",
 						Description: "description a",
 					},
 					{
@@ -1903,9 +1918,9 @@ func TestUnitMapCookiesPreferences(t *testing.T) {
 }
 
 func TestCleanDimensionsLabel(t *testing.T) {
-	Convey("Removes categories count from end of label - case insensitive", t, func() {
-		So(cleanDimensionLabel("Example (10 categories)"), ShouldEqual, "Example")
-		So(cleanDimensionLabel("Example (10 Categories)"), ShouldEqual, "Example")
+	Convey("Removes categories count from label - case insensitive", t, func() {
+		So(cleanDimensionLabel("Example (100 categories)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel("Example (7 Categories)"), ShouldEqual, "Example")
 		So(cleanDimensionLabel("Example (1 category)"), ShouldEqual, "Example")
 		So(cleanDimensionLabel("Example (1 Category)"), ShouldEqual, "Example")
 	})

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1902,6 +1902,15 @@ func TestUnitMapCookiesPreferences(t *testing.T) {
 	})
 }
 
+func TestCleanDimensionsLabel(t *testing.T) {
+	Convey("Removes categories count from end of label - case insensitive", t, func() {
+		So(cleanDimensionLabel("Example (10 categories)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel("Example (10 Categories)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel("Example (1 category)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel("Example (1 Category)"), ShouldEqual, "Example")
+	})
+}
+
 func getTestEmergencyBanner() zebedee.EmergencyBanner {
 	return zebedee.EmergencyBanner{
 		Type:        "notable_death",

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1923,6 +1923,9 @@ func TestCleanDimensionsLabel(t *testing.T) {
 		So(cleanDimensionLabel("Example (7 Categories)"), ShouldEqual, "Example")
 		So(cleanDimensionLabel("Example (1 category)"), ShouldEqual, "Example")
 		So(cleanDimensionLabel("Example (1 Category)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel(""), ShouldEqual, "")
+		So(cleanDimensionLabel("Example 1 category"), ShouldEqual, "Example 1 category")
+		So(cleanDimensionLabel("Example (something in brackets) (1 Category)"), ShouldEqual, "Example (something in brackets)")
 	})
 }
 


### PR DESCRIPTION
### What

The metadata service includes category count as part of the dimension label i.e. "Age (100 Categories)". This PR removes the (100 Categories) part.

Changes in filter-flex are made to ...

* Browse list of variables
* Search list of variables
* Variable tags on change dimension screen
* Review screen

![image](https://user-images.githubusercontent.com/6823289/211526317-0c956cfc-bed2-4822-9227-c25a0c51e151.png)


### How to review

Sense check
Media review
Tests pass

### Who can review

Frontend Go dev
