### PR TITLE
Do not pull categorisations for area dimensions

### DIFF
--- a/handlers/overview.go
+++ b/handlers/overview.go
@@ -322,7 +322,10 @@ func filterFlexOverview(w http.ResponseWriter, req *http.Request, f *FilterFlex,
 			return
 		}
 
-		categorisationCount, err := getDimensionCategorisations(filterJob.PopulationType, filterDimension.Name)
+		categorisationCount := 0
+		if !isAreaType(filterDimension) {
+			categorisationCount, err = getDimensionCategorisations(filterJob.PopulationType, filterDimension.Name)
+		}
 
 		filterDims.Items[i].Options = options
 		fDims = append(fDims, model.FilterDimension{


### PR DESCRIPTION
### What

Fix categorisations to avoid calling for area type dimensions

No new tests since the call is just an extra loop in a function that is already properly tested

### How to review

Tests pass
Sense check

### Who can review

!me
