### PR TITLE
Feature/6035 tweaks for byo

### DIFF
--- a/assets/templates/partials/summary.tmpl
+++ b/assets/templates/partials/summary.tmpl
@@ -3,19 +3,13 @@
     <h2 class="ons-u-fw-b">{{ localise "Variable" $lang 4 }}</h2>
     <div class="ons-summary ons-summary--hub">
         <div class="ons-summary__group">
-            <div class="ons-summary__items ons-u-mb-s">
+            <div class="ons-summary__items ons-u-mb-s ons-u-bt ons-u-bb">
                 {{ range $i, $dim := .Dimensions }}
                     <div class="ons-summary__item">
-                        <dl id="{{.ID}}" class="ons-summary__row ons-summary__row--has-values ons-grid--flex@xxs@m ons-grid--row@xxs@m ons-u-order--sb@xxs@m{{ if eq $i 0 }} ons-u-bt{{ end }}{{ if last $i $.Dimensions }} ons-u-bb{{ end }}">
+                        <dl id="{{.ID}}" class="ons-summary__row ons-summary__row--has-values ons-grid--flex@xxs@m ons-grid--row@xxs@m ons-u-order--sb@xxs@m{{ if eq $i 0 }} ons-u-bt{{ end }}">
                             <dt class="ons-summary__item-title ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-order--1@xxs@m ons-u-flex--2@xxs@m ons-col-4@m">
                                 <div class="ons-summary__item--text ons-u-fw-b">
-                                    {{ if .IsAreaType }}
-                                        {{- localise "AreaTypeDescription" $lang 1 -}}
-                                    {{ else if .IsCoverage}}
-                                        {{- localise "AreaTypeCoverageTitle" $lang 1 -}}
-                                    {{ else }}
-                                        {{- .Name -}}
-                                    {{ end }}
+                                    {{- .Name -}}
                                 </div>
                             </dt>
                             <dd class="ons-summary__values ons-u-pt-s ons-u-pb-s ons-u-pr-m ons-u-pl-no@xxs@m ons-u-order--3@xxs@m ons-u-fw@xxs@m
@@ -23,58 +17,42 @@
                                 {{ $length := len .Options }}
                                 {{ $strOptCount := intToString .OptionsCount }}
                                 {{ $isTruncated := .IsTruncated }}
-                                {{ if and (eq .IsAreaType false) (eq .IsCoverage false)  }}
+                                {{ $hasCategories := .HasCategories }}
+                                {{ $length := len .Options }}
+                                {{ if $hasCategories }}
                                     {{ localise "HasSelectedCategories" $lang 1 $strOptCount }}
                                     <div class="ons-u-mt-s ons-u-fs-s ons-list--container">
-                                        <ul class="ons-list{{ if $isTruncated }}--truncated{{end}}{{ if or (gt $length 9) ($isTruncated) }} ons-u-mb-xs{{else}}
+                                {{ end }}
+                                {{ if .Options }}
+                                    {{ if gt $length 1 }}
+                                        <ul class="ons-list{{if $isTruncated}}--truncated{{end}}{{ if or (gt $length 9) ($isTruncated) }} ons-u-mb-xs{{else}}
                                                 ons-u-m-no{{end}}">
-                                            {{ range $i, $opt := .Options }}
-                                                <li class="ons-list__item{{ if $isTruncated }}--truncated{{end}} ons-u-mb-no">
-                                                    {{ . }}
+                                            {{ range .Options }}
+                                                <li class="ons-list__item{{if $isTruncated}}--truncated{{end}} {{if $hasCategories }} ons-u-mb-no{{end}}">
+                                                    {{- . -}}
                                                 </li>
                                             {{ end }}
                                         </ul>
-                                        {{ if $isTruncated }}
-                                            <a href="{{.TruncateLink}}">{{- localise "TruncateShowAll" $lang 1 $strOptCount -}}</a>
-                                        {{ else if gt $length 9 }}
-                                            <a href="{{.TruncateLink}}">{{- localise "TruncateShowFewer" $lang 1 -}}</a>
-                                        {{ end }}
-                                    </div>
-                                {{ else }}
-                                    {{ if or (.IsAreaType) (.IsDefaultCoverage) }}
-                                        {{ if .IsDefaultCoverage }}
-                                            {{- localise "AreaTypeDefaultCoverage" $lang 1 -}}
-                                        {{ else if .IsAreaType }}
-                                            {{- .Name }}
-                                        {{ end }}
                                     {{ else }}
-                                        {{ if .Options }}
-                                            {{ if gt $length 1 }}
-                                                <ul class="ons-list ons-u-mb-no">
-                                                    {{ range $i, $opt := .Options }}
-                                                        <li class="ons-list__item">{{- . -}}</li>
-                                                    {{ end }}
-                                                </ul>
-                                            {{ else }}
-                                                {{- index .Options 0 -}}
-                                            {{ end }}
-                                        {{ end }}
+                                        {{- index .Options 0 -}}
                                     {{ end }}
                                 {{ end }}
+                                {{ if .HasCategories }}
+                                    {{ if $isTruncated }}
+                                        <a href="{{.TruncateLink}}">{{- localise "TruncateShowAll" $lang 1 $strOptCount -}}</a>
+                                    {{ else if gt $length 9 }}
+                                        <a href="{{.TruncateLink}}">{{- localise "TruncateShowFewer" $lang 1 -}}</a>
+                                    {{ end }}
+                                    </div>
+                                {{ end }}
                             </dd>
-                            {{ if or (.IsAreaType) (.IsCoverage) (.IsChangeCategories) }}
+                            {{ if .HasChange }}
                                 <dd class="ons-summary__actions ons-u-flex-ai-fs ons-u-pt-s ons-u-pb-s ons-u-pl-no@xxs ons-u-ml-xs@xxs ons-u-order--2@xxs@m
                                         ons-col-2@m">
                                     <a href="{{ .URI }}" class="ons-summary__button">
                                         {{ localise "Change" $lang 1 }}
                                         <span class="ons-u-vh">
-                                            {{ if .IsAreaType }}
-                                                {{- localise "AreaTypeDescription" $lang 1 -}}
-                                            {{ else if .IsCoverage }}
-                                                {{- localise "AreaTypeCoverageTitle" $lang 1 -}}
-                                            {{ else }}
-                                                {{- .Name -}}
-                                            {{ end }}
+                                            {{- .Name -}}
                                         </span>
                                     </a>
                                 </dd>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-filter-flex-dataset
 go 1.19
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.230.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.234.0
 	github.com/ONSdigital/dp-cookies v0.4.0
 	github.com/ONSdigital/dp-healthcheck v1.5.0
 	github.com/ONSdigital/dp-net/v2 v2.8.0
@@ -37,6 +37,7 @@ require (
 	github.com/nicksnyder/go-i18n/v2 v2.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 	github.com/smartystreets/assertions v1.13.0 // indirect
 	github.com/unrolled/render v1.5.0 // indirect
 	golang.org/x/net v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.230.0 h1:MpUdQUqmQDuC60baIj9O2mOZToll5blqOUDClbFozrs=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.230.0/go.mod h1:cUsVd/43nv1vsXo3s14yfig9wnJ8hcCcO4jGok97zC0=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.234.0 h1:wCNIuZ+4QyKtSS3IG7NtOKIsXVe9BUtm90BpjE1Pdd4=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.234.0/go.mod h1:PFfLdey8l0/ufzF6/x2mn+OL+9M5/xlg4JOQpFHmCbk=
 github.com/ONSdigital/dp-cookies v0.4.0 h1:B938xsFzj9OVM5yIRVVyteYYKjWN4Oz7i+u9+PEF8nk=
 github.com/ONSdigital/dp-cookies v0.4.0/go.mod h1:1xf96apIPNeV0WJs0UtKyM09laewXVUm/9bh84wFu7w=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
@@ -114,6 +114,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be/go.mod h1:MIDFMn7db1kT65GmV94GzpX9Qdi7N/pQlwb+AN8wh+Q=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dkQrfxh/abbBAOZBVp0ds+fBEOUOqOc=
+github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/assertions v1.13.0 h1:Dx1kYM01xsSqKPno3aqLnrwac2LetPvN23diwyr69Qs=

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -63,6 +63,7 @@ type PopulationClient interface {
 	GetDimensionCategories(ctx context.Context, input population.GetDimensionCategoryInput) (population.GetDimensionCategoriesResponse, error)
 	GetDimensionsDescription(ctx context.Context, input population.GetDimensionsDescriptionInput) (population.GetDimensionsResponse, error)
 	GetParentAreaCount(ctx context.Context, input population.GetParentAreaCountInput) (int, error)
+	GetPopulationTypes(ctx context.Context, input population.GetPopulationTypesInput) (population.GetPopulationTypesResponse, error)
 }
 
 // ZebedeeClient is an interface with methods required for the zebedee client

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
@@ -56,7 +57,7 @@ type PopulationClient interface {
 	GetAreas(ctx context.Context, input population.GetAreasInput) (population.GetAreasResponse, error)
 	GetAreaTypeParents(ctx context.Context, input population.GetAreaTypeParentsInput) (population.GetAreaTypeParentsResponse, error)
 	GetArea(ctx context.Context, input population.GetAreaInput) (population.GetAreaResponse, error)
-	GetBlockedAreaCount(ctx context.Context, input population.GetBlockedAreaCountInput) (*population.GetBlockedAreaCountResult, error)
+	GetBlockedAreaCount(ctx context.Context, input population.GetBlockedAreaCountInput) (*cantabular.GetBlockedAreaCountResult, error)
 	GetCategorisations(ctx context.Context, input population.GetCategorisationsInput) (population.GetCategorisationsResponse, error)
 	GetDimensions(ctx context.Context, input population.GetDimensionsInput) (population.GetDimensionsResponse, error)
 	GetDimensionCategories(ctx context.Context, input population.GetDimensionCategoryInput) (population.GetDimensionCategoriesResponse, error)

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -8,6 +8,7 @@ import (
 
 	"net/http"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
@@ -79,7 +80,7 @@ func setStatusCode(req *http.Request, w http.ResponseWriter, err error) {
 }
 
 // getBlockedAreaCount is a helper function that does the required sorting and checks before making the api request
-func (f *FilterFlex) getBlockedAreaCount(ctx context.Context, accessToken, populationType, areaTypeID, parent string, dimensionIds, areaOptions []string) (*population.GetBlockedAreaCountResult, error) {
+func (f *FilterFlex) getBlockedAreaCount(ctx context.Context, accessToken, populationType, areaTypeID, parent string, dimensionIds, areaOptions []string) (*cantabular.GetBlockedAreaCountResult, error) {
 	sort.Slice(dimensionIds, func(i, j int) bool {
 		return dimensionIds[i] == areaTypeID || dimensionIds[i] == parent
 	})

--- a/handlers/get_change_dimensions_test.go
+++ b/handlers/get_change_dimensions_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
@@ -93,7 +94,7 @@ func TestGetChangeDimensionsHandler(t *testing.T) {
 				mockPc.
 					EXPECT().
 					GetBlockedAreaCount(gomock.Any(), gomock.Any()).
-					Return(&population.GetBlockedAreaCountResult{}, nil)
+					Return(&cantabular.GetBlockedAreaCountResult{}, nil)
 
 				mockZc := NewMockZebedeeClient(mockCtrl)
 				mockZc.
@@ -171,7 +172,7 @@ func TestGetChangeDimensionsHandler(t *testing.T) {
 				mockPc.
 					EXPECT().
 					GetBlockedAreaCount(gomock.Any(), gomock.Any()).
-					Return(&population.GetBlockedAreaCountResult{}, nil)
+					Return(&cantabular.GetBlockedAreaCountResult{}, nil)
 
 				mockZc := NewMockZebedeeClient(mockCtrl)
 				mockZc.
@@ -303,7 +304,7 @@ func TestGetChangeDimensionsHandler(t *testing.T) {
 				mockPc.
 					EXPECT().
 					GetBlockedAreaCount(gomock.Any(), gomock.Any()).
-					Return(&population.GetBlockedAreaCountResult{}, nil)
+					Return(&cantabular.GetBlockedAreaCountResult{}, nil)
 
 				mockZc := NewMockZebedeeClient(mockCtrl)
 				mockZc.
@@ -672,7 +673,7 @@ func TestGetChangeDimensionsHandler(t *testing.T) {
 				mockPc.
 					EXPECT().
 					GetBlockedAreaCount(gomock.Any(), gomock.Any()).
-					Return(&population.GetBlockedAreaCountResult{}, errors.New("Internal error"))
+					Return(&cantabular.GetBlockedAreaCountResult{}, errors.New("Internal error"))
 
 				mockZc := NewMockZebedeeClient(mockCtrl)
 				mockZc.

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -583,6 +583,21 @@ func (mr *MockPopulationClientMockRecorder) GetParentAreaCount(ctx, input interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParentAreaCount", reflect.TypeOf((*MockPopulationClient)(nil).GetParentAreaCount), ctx, input)
 }
 
+// GetPopulationTypes mocks base method.
+func (m *MockPopulationClient) GetPopulationTypes(ctx context.Context, input population.GetPopulationTypesInput) (population.GetPopulationTypesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPopulationTypes", ctx, input)
+	ret0, _ := ret[0].(population.GetPopulationTypesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPopulationTypes indicates an expected call of GetPopulationTypes.
+func (mr *MockPopulationClientMockRecorder) GetPopulationTypes(ctx, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPopulationTypes", reflect.TypeOf((*MockPopulationClient)(nil).GetPopulationTypes), ctx, input)
+}
+
 // MockZebedeeClient is a mock of ZebedeeClient interface.
 type MockZebedeeClient struct {
 	ctrl     *gomock.Controller

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -9,6 +9,7 @@ import (
 	io "io"
 	reflect "reflect"
 
+	cantabular "github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	dataset "github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	filter "github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	population "github.com/ONSdigital/dp-api-clients-go/v2/population"
@@ -493,10 +494,10 @@ func (mr *MockPopulationClientMockRecorder) GetAreas(ctx, input interface{}) *go
 }
 
 // GetBlockedAreaCount mocks base method.
-func (m *MockPopulationClient) GetBlockedAreaCount(ctx context.Context, input population.GetBlockedAreaCountInput) (*population.GetBlockedAreaCountResult, error) {
+func (m *MockPopulationClient) GetBlockedAreaCount(ctx context.Context, input population.GetBlockedAreaCountInput) (*cantabular.GetBlockedAreaCountResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockedAreaCount", ctx, input)
-	ret0, _ := ret[0].(*population.GetBlockedAreaCountResult)
+	ret0, _ := ret[0].(*cantabular.GetBlockedAreaCountResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -521,7 +522,7 @@ func (mr *MockPopulationClientMockRecorder) GetCategorisations(ctx, input interf
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCategorisations", reflect.TypeOf((*MockPopulationClient)(nil).GetCategorisations), ctx, input)
 }
- 
+
 // GetDimensionCategories mocks base method.
 func (m *MockPopulationClient) GetDimensionCategories(ctx context.Context, input population.GetDimensionCategoryInput) (population.GetDimensionCategoriesResponse, error) {
 	m.ctrl.T.Helper()

--- a/handlers/overview.go
+++ b/handlers/overview.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
@@ -34,7 +35,7 @@ func filterFlexOverview(w http.ResponseWriter, req *http.Request, f *FilterFlex,
 	var dimCategories population.GetDimensionCategoriesResponse
 	var filterJob *filter.GetFilterResponse
 	var eb zebedee.EmergencyBanner
-	var sdc *population.GetBlockedAreaCountResult
+	var sdc *cantabular.GetBlockedAreaCountResult
 	var fErr, dErr, fdsErr, imErr, zErr, sErr, dcErr error
 	var isMultivariate bool
 	var serviceMsg, areaTypeID, parent string
@@ -346,7 +347,7 @@ func filterFlexOverview(w http.ResponseWriter, req *http.Request, f *FilterFlex,
 			return
 		}
 	} else {
-		sdc = &population.GetBlockedAreaCountResult{}
+		sdc = &cantabular.GetBlockedAreaCountResult{}
 	}
 
 	basePage := f.Render.NewBasePageModel()

--- a/handlers/overview.go
+++ b/handlers/overview.go
@@ -195,7 +195,6 @@ func filterFlexOverview(w http.ResponseWriter, req *http.Request, f *FilterFlex,
 		return cats.PaginationResponse.TotalCount, err
 	}
 
-	var hasNoAreaOptions bool
 	getAreaOptions := func(dim filter.Dimension) ([]string, int, error) {
 		q := filter.QueryParams{Offset: 0, Limit: 500}
 		opts, _, err := f.FilterClient.GetDimensionOptions(ctx, accessToken, "", collectionID, filterID, dim.Name, &q)
@@ -219,7 +218,6 @@ func filterFlexOverview(w http.ResponseWriter, req *http.Request, f *FilterFlex,
 				return nil, 0, fmt.Errorf("failed to get dimension areas: %w", err)
 			}
 
-			hasNoAreaOptions = true
 			return options, areas.TotalCount, nil
 		}
 
@@ -353,7 +351,7 @@ func filterFlexOverview(w http.ResponseWriter, req *http.Request, f *FilterFlex,
 
 	basePage := f.Render.NewBasePageModel()
 	m := mapper.NewMapper(req, basePage, eb, lang, serviceMsg, filterID)
-	overview := m.CreateFilterFlexOverview(*filterJob, fDims, dimDescriptions, *sdc, hasNoAreaOptions, isMultivariate)
+	overview := m.CreateFilterFlexOverview(*filterJob, fDims, dimDescriptions, *sdc, isMultivariate)
 	f.Render.BuildPage(w, overview, "overview")
 }
 

--- a/handlers/overview_test.go
+++ b/handlers/overview_test.go
@@ -93,6 +93,10 @@ func TestOverviewHandler(t *testing.T) {
 						PaginationResponse: population.PaginationResponse{TotalCount: 1},
 						Categories:         mockDimensionCategories,
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -146,6 +150,10 @@ func TestOverviewHandler(t *testing.T) {
 						PaginationResponse: population.PaginationResponse{TotalCount: 1},
 						Categories:         mockDimensionCategories,
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -193,6 +201,10 @@ func TestOverviewHandler(t *testing.T) {
 						PaginationResponse: population.PaginationResponse{TotalCount: 1},
 						Categories:         mockDimensionCategories,
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -259,6 +271,10 @@ func TestOverviewHandler(t *testing.T) {
 								TotalCount: 2,
 							},
 						}, nil).AnyTimes()
+					mockPc.
+						EXPECT().
+						GetPopulationTypes(ctx, gomock.Any()).
+						Return(population.GetPopulationTypesResponse{}, nil)
 
 					mockDc := NewMockDatasetClient(mockCtrl)
 					mockDc.
@@ -350,6 +366,10 @@ func TestOverviewHandler(t *testing.T) {
 									TotalCount: 2,
 								},
 							}, nil).AnyTimes()
+						mockPc.
+							EXPECT().
+							GetPopulationTypes(ctx, gomock.Any()).
+							Return(population.GetPopulationTypesResponse{}, nil)
 
 						mockRend := NewMockRenderClient(mockCtrl)
 						mockRend.
@@ -448,6 +468,10 @@ func TestOverviewHandler(t *testing.T) {
 									TotalCount: 2,
 								},
 							}, nil).AnyTimes()
+						mockPc.
+							EXPECT().
+							GetPopulationTypes(ctx, gomock.Any()).
+							Return(population.GetPopulationTypesResponse{}, nil)
 
 						mockRend := NewMockRenderClient(mockCtrl)
 						mockRend.
@@ -552,6 +576,10 @@ func TestOverviewHandler(t *testing.T) {
 									TotalCount: 2,
 								},
 							}, nil).AnyTimes()
+						mockPc.
+							EXPECT().
+							GetPopulationTypes(ctx, gomock.Any()).
+							Return(population.GetPopulationTypesResponse{}, nil)
 
 						mockRend := NewMockRenderClient(mockCtrl)
 						mockRend.
@@ -662,6 +690,10 @@ func TestOverviewHandler(t *testing.T) {
 									TotalCount: 2,
 								},
 							}, nil).AnyTimes()
+						mockPc.
+							EXPECT().
+							GetPopulationTypes(ctx, gomock.Any()).
+							Return(population.GetPopulationTypesResponse{}, nil)
 
 						// TODO: pc.GetParentAreaCount is causing production issues
 						// mockPc.
@@ -743,6 +775,10 @@ func TestOverviewHandler(t *testing.T) {
 							TotalCount: 2,
 						},
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -793,6 +829,10 @@ func TestOverviewHandler(t *testing.T) {
 							TotalCount: 2,
 						},
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -857,6 +897,10 @@ func TestOverviewHandler(t *testing.T) {
 							TotalCount: 2,
 						},
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -942,6 +986,10 @@ func TestOverviewHandler(t *testing.T) {
 							TotalCount: 2,
 						},
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
 
 				mockRend := NewMockRenderClient(mockCtrl)
 
@@ -1010,6 +1058,10 @@ func TestOverviewHandler(t *testing.T) {
 							TotalCount: 2,
 						},
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
@@ -1086,6 +1138,66 @@ func TestOverviewHandler(t *testing.T) {
 							TotalCount: 2,
 						},
 					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, nil)
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)
+
+				ff := NewFilterFlex(mockRend, mockFc, mockDc, mockPc, mockZc, cfg)
+				router := mux.NewRouter()
+				router.HandleFunc("/filters/12345/dimensions", ff.FilterFlexOverview())
+				router.ServeHTTP(w, req)
+
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+
+			Convey("test FilterFlexOverview returns 500 if pc.GetPopulationTypes returns an error", func() {
+				mockFilterDims := filter.Dimensions{
+					Items: []filter.Dimension{
+						{
+							Name:       "Test",
+							IsAreaType: new(bool),
+						},
+					},
+				}
+
+				mockFc := NewMockFilterClient(mockCtrl)
+				mockFc.
+					EXPECT().
+					GetFilter(ctx, gomock.Any()).
+					Return(&filter.GetFilterResponse{}, nil)
+				mockFc.
+					EXPECT().
+					GetDimensions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(mockFilterDims, "", nil)
+
+				mockDc := NewMockDatasetClient(mockCtrl)
+				mockDc.
+					EXPECT().
+					Get(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(dataset.DatasetDetails{}, nil)
+
+				mockPc := NewMockPopulationClient(mockCtrl)
+				mockPc.
+					EXPECT().
+					GetDimensionCategories(ctx, gomock.Any()).
+					Return(population.GetDimensionCategoriesResponse{
+						PaginationResponse: population.PaginationResponse{TotalCount: 1},
+						Categories:         mockDimensionCategories,
+					}, nil).AnyTimes()
+				mockPc.
+					EXPECT().
+					GetPopulationTypes(ctx, gomock.Any()).
+					Return(population.GetPopulationTypesResponse{}, errors.New("Sorry"))
+
+				mockZc := NewMockZebedeeClient(mockCtrl)
+				mockZc.
+					EXPECT().
+					GetHomepageContent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(zebedee.HomepageContent{}, nil)
 
 				w := httptest.NewRecorder()
 				req := httptest.NewRequest("GET", "/filters/12345/dimensions", nil)

--- a/handlers/overview_test.go
+++ b/handlers/overview_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
@@ -645,7 +646,7 @@ func TestOverviewHandler(t *testing.T) {
 						mockPc.
 							EXPECT().
 							GetBlockedAreaCount(gomock.Any(), gomock.Any()).
-							Return(&population.GetBlockedAreaCountResult{}, nil)
+							Return(&cantabular.GetBlockedAreaCountResult{}, nil)
 						mockPc.
 							EXPECT().
 							GetDimensionCategories(ctx, gomock.Any()).
@@ -926,7 +927,7 @@ func TestOverviewHandler(t *testing.T) {
 				mockPc.
 					EXPECT().
 					GetBlockedAreaCount(gomock.Any(), gomock.Any()).
-					Return(&population.GetBlockedAreaCountResult{}, errors.New("Sorry"))
+					Return(&cantabular.GetBlockedAreaCountResult{}, errors.New("Sorry"))
 				mockPc.
 					EXPECT().
 					GetDimensionCategories(ctx, gomock.Any()).

--- a/mapper/collapsible.go
+++ b/mapper/collapsible.go
@@ -17,9 +17,9 @@ type Link struct {
 func mapImproveResultsCollapsible(dims []model.Dimension) (areaTypeUri string, linksItem string) {
 	var dimsLinks []Link
 	for _, dim := range dims {
-		if dim.IsAreaType {
+		if dim.IsGeography {
 			areaTypeUri = dim.URI
-		} else if dim.Name != "" && dim.IsChangeCategories {
+		} else if dim.Name != "" && dim.HasChange {
 			dimsLinks = append(dimsLinks, Link{
 				Uri:  dim.URI,
 				Text: dim.Name,
@@ -51,12 +51,12 @@ func mapDescriptionsCollapsible(dimDescriptions population.GetDimensionsResponse
 
 	for _, dim := range dims {
 		for _, dimDescription := range dimDescriptions.Dimensions {
-			if dim.ID == dimDescription.ID && !dim.IsAreaType {
+			if dim.ID == dimDescription.ID && !dim.IsGeography {
 				collapsibleContentItems = append(collapsibleContentItems, coreModel.CollapsibleItem{
 					Subheading: cleanDimensionLabel(dimDescription.Label),
 					Content:    strings.Split(dimDescription.Description, "\n"),
 				})
-			} else if dim.ID == dimDescription.ID && dim.IsAreaType {
+			} else if dim.ID == dimDescription.ID && dim.IsGeography {
 				areaItem.Subheading = cleanDimensionLabel(dimDescription.Label)
 				areaItem.Content = strings.Split(dimDescription.Description, "\n")
 			}

--- a/mapper/collapsible_test.go
+++ b/mapper/collapsible_test.go
@@ -99,17 +99,17 @@ func TestMapImproveResultsCollapsible(t *testing.T) {
 		Convey("When the mapImproveResultsCollapsible function is called", func() {
 			mockDims := []model.Dimension{
 				{
-					Name:       "Test area dim",
-					ID:         "test_dim_1",
-					URI:        "/test_dim_1",
-					IsAreaType: true,
+					Name:        "Test area dim",
+					ID:          "test_dim_1",
+					URI:         "/test_dim_1",
+					IsGeography: true,
 				},
 				{
-					Name:               "Test dim 2",
-					ID:                 "test_dim_2",
-					URI:                "/test_dim_2",
-					IsAreaType:         false,
-					IsChangeCategories: true,
+					Name:        "Test dim 2",
+					ID:          "test_dim_2",
+					URI:         "/test_dim_2",
+					IsGeography: false,
+					HasChange:   true,
 				},
 			}
 			areaUri, dimLink := mapImproveResultsCollapsible(mockDims)
@@ -127,24 +127,24 @@ func TestMapImproveResultsCollapsible(t *testing.T) {
 		Convey("When the mapImproveResultsCollapsible function is called", func() {
 			mockDims := []model.Dimension{
 				{
-					Name:       "Test area dim",
-					ID:         "test_dim_1",
-					URI:        "/test_dim_1",
-					IsAreaType: true,
+					Name:        "Test area dim",
+					ID:          "test_dim_1",
+					URI:         "/test_dim_1",
+					IsGeography: true,
 				},
 				{
-					Name:               "Test dim 2",
-					ID:                 "test_dim_2",
-					URI:                "/test_dim_2",
-					IsAreaType:         false,
-					IsChangeCategories: false,
+					Name:        "Test dim 2",
+					ID:          "test_dim_2",
+					URI:         "/test_dim_2",
+					IsGeography: false,
+					HasChange:   false,
 				},
 				{
-					Name:               "Test dim 3",
-					ID:                 "test_dim_3",
-					URI:                "/test_dim_3",
-					IsAreaType:         false,
-					IsChangeCategories: true,
+					Name:        "Test dim 3",
+					ID:          "test_dim_3",
+					URI:         "/test_dim_3",
+					IsGeography: false,
+					HasChange:   true,
 				},
 			}
 			_, dimLink := mapImproveResultsCollapsible(mockDims)
@@ -182,16 +182,16 @@ func TestMapDescriptionsCollapsible(t *testing.T) {
 
 			mockPageDims := []model.Dimension{
 				{
-					Name:       "Test area dim",
-					ID:         "test_dim_1",
-					URI:        "/test_dim_1",
-					IsAreaType: true,
+					Name:        "Test area dim",
+					ID:          "test_dim_1",
+					URI:         "/test_dim_1",
+					IsGeography: true,
 				},
 				{
-					Name:       "Test dim 2",
-					ID:         "test_dim_2",
-					URI:        "/test_dim_2",
-					IsAreaType: false,
+					Name:        "Test dim 2",
+					ID:          "test_dim_2",
+					URI:         "/test_dim_2",
+					IsGeography: false,
 				},
 			}
 			sut := mapDescriptionsCollapsible(mockDescriptions, mockPageDims)

--- a/mapper/dimensions.go
+++ b/mapper/dimensions.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"fmt"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/model"
 	"github.com/ONSdigital/dp-renderer/helper"
@@ -10,7 +11,7 @@ import (
 )
 
 // CreateGetChangeDimensions maps data to the ChangeDimensions model
-func (m *Mapper) CreateGetChangeDimensions(q, formAction string, dims []model.FilterDimension, pDims, results population.GetDimensionsResponse, sdc *population.GetBlockedAreaCountResult) model.ChangeDimensions {
+func (m *Mapper) CreateGetChangeDimensions(q, formAction string, dims []model.FilterDimension, pDims, results population.GetDimensionsResponse, sdc *cantabular.GetBlockedAreaCountResult) model.ChangeDimensions {
 	p := model.ChangeDimensions{
 		Page: m.basePage,
 	}

--- a/mapper/dimensions.go
+++ b/mapper/dimensions.go
@@ -33,10 +33,10 @@ func (m *Mapper) CreateGetChangeDimensions(q, formAction string, dims []model.Fi
 			})
 		}
 		pageDims = append(pageDims, model.Dimension{
-			IsAreaType: *dim.IsAreaType,
-			ID:         dim.ID,
-			URI:        fmt.Sprintf("/filters/%s/dimensions/%s", m.fid, dim.Name),
-			Name:       cleanDimensionLabel(dim.Label),
+			IsGeography: *dim.IsAreaType,
+			ID:          dim.ID,
+			URI:         fmt.Sprintf("/filters/%s/dimensions/%s", m.fid, dim.Name),
+			Name:        cleanDimensionLabel(dim.Label),
 		})
 	}
 	p.Output.Selections = selections

--- a/mapper/dimensions_test.go
+++ b/mapper/dimensions_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/helpers"
@@ -87,7 +88,7 @@ func TestGetChangeDimensions(t *testing.T) {
 				mockFds,
 				mockPds,
 				mockPdsR,
-				&population.GetBlockedAreaCountResult{},
+				&cantabular.GetBlockedAreaCountResult{},
 			)
 			Convey("Then it maps page metadata", func() {
 				So(p.BetaBannerEnabled, ShouldBeTrue)
@@ -210,7 +211,7 @@ func TestGetChangeDimensions(t *testing.T) {
 				[]model.FilterDimension{},
 				population.GetDimensionsResponse{},
 				population.GetDimensionsResponse{},
-				&population.GetBlockedAreaCountResult{},
+				&cantabular.GetBlockedAreaCountResult{},
 			)
 			Convey("then it sets HasNoResults to true", func() {
 				So(p.SearchOutput.HasNoResults, ShouldBeTrue)
@@ -218,7 +219,7 @@ func TestGetChangeDimensions(t *testing.T) {
 		})
 
 		Convey("when areas are blocked", func() {
-			mockSdc := population.GetBlockedAreaCountResult{
+			mockSdc := cantabular.GetBlockedAreaCountResult{
 				Passed:  10,
 				Blocked: 20,
 				Total:   0,

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-cookies/cookies"
@@ -217,7 +218,7 @@ func mapPanel(locale coreModel.Localisation, language string, utilityCssClasses 
 }
 
 // mapBlockedAreasPanel is a helper function that returns the blocked areas panel
-func (m *Mapper) mapBlockedAreasPanel(sdc *population.GetBlockedAreaCountResult, panelType model.PanelType) (p *model.Panel) {
+func (m *Mapper) mapBlockedAreasPanel(sdc *cantabular.GetBlockedAreaCountResult, panelType model.PanelType) (p *model.Panel) {
 	switch panelType {
 	case model.Pending:
 		p = &model.Panel{

--- a/mapper/overview.go
+++ b/mapper/overview.go
@@ -15,7 +15,7 @@ import (
 )
 
 // CreateFilterFlexOverview maps data to the Overview model
-func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, filterDims []model.FilterDimension, dimDescriptions population.GetDimensionsResponse, sdc population.GetBlockedAreaCountResult, hasNoAreaOptions, isMultivariate bool) model.Overview {
+func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, filterDims []model.FilterDimension, dimDescriptions population.GetDimensionsResponse, sdc population.GetBlockedAreaCountResult, isMultivariate bool) model.Overview {
 	queryStrValues := m.req.URL.Query()["showAll"]
 	path := m.req.URL.Path
 
@@ -37,52 +37,77 @@ func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, fi
 		},
 	}
 
+	pop := model.Dimension{
+		Name:        "Population type",
+		Options:     []string{"Usual residents"},
+		ID:          filterJob.PopulationType,
+		IsGeography: true,
+	}
+
+	coverage := model.Dimension{
+		Name:        helper.Localise("AreaTypeCoverageTitle", m.lang, 1),
+		IsGeography: true,
+		HasChange:   true,
+		URI:         fmt.Sprintf("%s/geography/coverage", path),
+		ID:          "coverage",
+	}
+
+	var area model.Dimension
 	for _, dim := range filterDims {
-		pageDim := model.Dimension{}
-		pageDim.Name = cleanDimensionLabel(dim.Label)
-		pageDim.IsAreaType = *dim.IsAreaType
-		pageDim.OptionsCount = dim.OptionsCount
-		pageDim.ID = dim.ID
-		pageDim.URI = fmt.Sprintf("%s/%s", path, dim.Name)
-		pageDim.IsChangeCategories = isMultivariate && dim.CategorisationCount > 1
-
-		q := url.Values{}
-		midFloor, midCeiling := getTruncationMidRange(dim.OptionsCount)
-
-		var displayedOptions []string
-		if len(dim.Options) > 9 && !helpers.HasStringInSlice(dim.Name, queryStrValues) && !*dim.IsAreaType {
-			displayedOptions = append(displayedOptions, dim.Options[:3]...)
-			displayedOptions = append(displayedOptions, dim.Options[midFloor:midCeiling]...)
-			displayedOptions = append(displayedOptions, dim.Options[len(dim.Options)-3:]...)
-			q.Add(queryStrKey, dim.Name)
-			helpers.PersistExistingParams(queryStrValues, queryStrKey, dim.Name, q)
-			pageDim.IsTruncated = true
+		if *dim.IsAreaType {
+			area.Name = helper.Localise("AreaTypeDescription", m.lang, 1)
+			area.Options = []string{cleanDimensionLabel(dim.Label)}
+			area.IsGeography = true
+			area.OptionsCount = dim.OptionsCount
+			coverage.Options = dim.Options
+			area.ID = dim.ID
+			area.URI = fmt.Sprintf("%s/%s", path, dim.Name)
+			area.HasChange = true
 		} else {
-			helpers.PersistExistingParams(queryStrValues, queryStrKey, dim.Name, q)
-			displayedOptions = dim.Options
-			pageDim.IsTruncated = false
-		}
+			pageDim := model.Dimension{}
+			pageDim.Name = cleanDimensionLabel(dim.Label)
+			pageDim.OptionsCount = dim.OptionsCount
+			pageDim.IsGeography = *dim.IsAreaType
+			pageDim.ID = dim.ID
+			pageDim.URI = fmt.Sprintf("%s/%s", path, dim.Name)
+			pageDim.HasChange = isMultivariate && dim.CategorisationCount > 1
+			pageDim.HasCategories = true
+			q := url.Values{}
+			midFloor, midCeiling := getTruncationMidRange(dim.OptionsCount)
 
-		pageDim.Options = append(pageDim.Options, displayedOptions...)
-		pageDim.TruncateLink = generateTruncatePath(path, dim.ID, q)
-		p.Dimensions = append(p.Dimensions, pageDim)
+			var displayedOptions []string
+			if len(dim.Options) > 9 && !helpers.HasStringInSlice(dim.Name, queryStrValues) {
+				displayedOptions = append(displayedOptions, dim.Options[:3]...)
+				displayedOptions = append(displayedOptions, dim.Options[midFloor:midCeiling]...)
+				displayedOptions = append(displayedOptions, dim.Options[len(dim.Options)-3:]...)
+				q.Add(queryStrKey, dim.Name)
+				helpers.PersistExistingParams(queryStrValues, queryStrKey, dim.Name, q)
+				pageDim.IsTruncated = true
+			} else {
+				helpers.PersistExistingParams(queryStrValues, queryStrKey, dim.Name, q)
+				displayedOptions = dim.Options
+				pageDim.IsTruncated = false
+			}
+
+			pageDim.Options = append(pageDim.Options, displayedOptions...)
+			pageDim.TruncateLink = generateTruncatePath(path, dim.ID, q)
+			p.Dimensions = append(p.Dimensions, pageDim)
+		}
+	}
+
+	if len(coverage.Options) == 0 {
+		coverage.Options = []string{helper.Localise("AreaTypeDefaultCoverage", m.lang, 1)}
 	}
 
 	sort.Slice(p.Dimensions, func(i, j int) bool {
-		return p.Dimensions[i].IsAreaType
+		return p.Dimensions[i].Name < p.Dimensions[j].Name
 	})
 
-	coverage := []model.Dimension{
-		{
-			IsCoverage:        true,
-			IsDefaultCoverage: hasNoAreaOptions,
-			URI:               fmt.Sprintf("%s/geography/coverage", path),
-			Options:           p.Dimensions[0].Options,
-			ID:                "coverage",
-		},
-	}
-	temp := append(coverage, p.Dimensions[1:]...)
-	p.Dimensions = append(p.Dimensions[:1], temp...)
+	p.Dimensions = append([]model.Dimension{
+		pop,
+		area,
+		coverage,
+	}, p.Dimensions...)
 
 	p.DimensionDescriptions = coreModel.Collapsible{
 		Title: coreModel.Localisation{
@@ -118,7 +143,7 @@ func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, fi
 			p.Panel = *m.mapBlockedAreasPanel(&sdc, model.Success)
 		}
 
-		p.EnableGetData = len(p.Dimensions) > 2
+		p.EnableGetData = len(p.Dimensions) > 3 // all geography dimensions (population type, area type and coverage)
 	} else {
 		p.EnableGetData = true
 	}

--- a/mapper/overview.go
+++ b/mapper/overview.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/helpers"
@@ -15,7 +16,7 @@ import (
 )
 
 // CreateFilterFlexOverview maps data to the Overview model
-func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, filterDims []model.FilterDimension, dimDescriptions population.GetDimensionsResponse, sdc population.GetBlockedAreaCountResult, isMultivariate bool) model.Overview {
+func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, filterDims []model.FilterDimension, dimDescriptions population.GetDimensionsResponse, sdc cantabular.GetBlockedAreaCountResult, isMultivariate bool) model.Overview {
 	queryStrValues := m.req.URL.Query()["showAll"]
 	path := m.req.URL.Path
 

--- a/mapper/overview.go
+++ b/mapper/overview.go
@@ -16,7 +16,7 @@ import (
 )
 
 // CreateFilterFlexOverview maps data to the Overview model
-func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, filterDims []model.FilterDimension, dimDescriptions population.GetDimensionsResponse, sdc cantabular.GetBlockedAreaCountResult, isMultivariate bool) model.Overview {
+func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, filterDims []model.FilterDimension, dimDescriptions population.GetDimensionsResponse, pops population.GetPopulationTypesResponse, sdc cantabular.GetBlockedAreaCountResult, isMultivariate bool) model.Overview {
 	queryStrValues := m.req.URL.Query()["showAll"]
 	path := m.req.URL.Path
 
@@ -40,9 +40,15 @@ func (m *Mapper) CreateFilterFlexOverview(filterJob filter.GetFilterResponse, fi
 
 	pop := model.Dimension{
 		Name:        "Population type",
-		Options:     []string{"Usual residents"},
 		ID:          filterJob.PopulationType,
 		IsGeography: true,
+	}
+
+	for _, population := range pops.Items {
+		if population.Name == filterJob.PopulationType {
+			pop.Options = []string{population.Label}
+			break
+		}
 	}
 
 	coverage := model.Dimension{

--- a/mapper/overview_test.go
+++ b/mapper/overview_test.go
@@ -135,7 +135,7 @@ func TestOverview(t *testing.T) {
 	}
 
 	Convey("test filter flex overview maps correctly", t, func() {
-		overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false, false)
+		overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false)
 		So(overview.BetaBannerEnabled, ShouldBeTrue)
 		So(overview.Type, ShouldEqual, "review_changes")
 		So(overview.Metadata.Title, ShouldEqual, "Review changes")
@@ -148,36 +148,36 @@ func TestOverview(t *testing.T) {
 		So(overview.SearchNoIndexEnabled, ShouldBeTrue)
 		So(overview.IsMultivariate, ShouldBeFalse)
 
-		So(overview.Dimensions[0].Name, ShouldEqual, filterDims[3].Label)
-		So(overview.Dimensions[0].IsAreaType, ShouldBeTrue)
-		So(overview.Dimensions[0].IsCoverage, ShouldBeFalse)
-		So(overview.Dimensions[0].Options, ShouldResemble, filterDims[3].Options)
-		So(overview.Dimensions[0].OptionsCount, ShouldEqual, filterDims[3].OptionsCount)
-		So(overview.Dimensions[0].ID, ShouldEqual, filterDims[3].ID)
-		So(overview.Dimensions[0].URI, ShouldEqual, fmt.Sprintf("/dimensions/%s", filterDims[3].Name))
-		So(overview.Dimensions[0].IsTruncated, ShouldBeFalse)
+		So(overview.Dimensions[0].Name, ShouldEqual, "Population type")
+		So(overview.Dimensions[0].Options[0], ShouldEqual, "Usual residents")
+		So(overview.Dimensions[0].IsGeography, ShouldBeTrue)
 
-		So(overview.Dimensions[1].Name, ShouldBeBlank)
-		So(overview.Dimensions[1].IsAreaType, ShouldBeFalse)
-		So(overview.Dimensions[1].IsCoverage, ShouldBeTrue)
-		So(overview.Dimensions[1].IsDefaultCoverage, ShouldBeFalse)
-		So(overview.Dimensions[1].Options, ShouldResemble, filterDims[3].Options)
-		So(overview.Dimensions[1].URI, ShouldEqual, "/dimensions/geography/coverage")
+		So(overview.Dimensions[1].Name, ShouldEqual, "Area type")
+		So(overview.Dimensions[1].IsGeography, ShouldBeTrue)
+		So(overview.Dimensions[1].OptionsCount, ShouldEqual, filterDims[3].OptionsCount)
+		So(overview.Dimensions[1].ID, ShouldEqual, filterDims[3].ID)
+		So(overview.Dimensions[1].URI, ShouldEqual, fmt.Sprintf("/dimensions/%s", filterDims[3].Name))
 		So(overview.Dimensions[1].IsTruncated, ShouldBeFalse)
 
-		So(overview.Dimensions[2].Name, ShouldEqual, filterDims[0].Label)
-		So(overview.Dimensions[2].IsAreaType, ShouldBeFalse)
-		So(overview.Dimensions[2].IsCoverage, ShouldBeFalse)
-		So(overview.Dimensions[2].ID, ShouldEqual, filterDims[0].ID)
-		So(overview.Dimensions[2].URI, ShouldEqual, fmt.Sprintf("/dimensions/%s", filterDims[0].Name))
+		So(overview.Dimensions[2].Name, ShouldEqual, "Coverage")
+		So(overview.Dimensions[2].IsGeography, ShouldBeTrue)
+		So(overview.Dimensions[2].Options, ShouldResemble, filterDims[3].Options)
+		So(overview.Dimensions[2].URI, ShouldEqual, "/dimensions/geography/coverage")
 		So(overview.Dimensions[2].IsTruncated, ShouldBeFalse)
 
-		So(overview.Dimensions[3].Name, ShouldEqual, filterDims[1].Label)
-		So(overview.Dimensions[3].IsAreaType, ShouldBeFalse)
-		So(overview.Dimensions[3].IsCoverage, ShouldBeFalse)
-		So(overview.Dimensions[3].ID, ShouldEqual, filterDims[1].ID)
-		So(overview.Dimensions[3].URI, ShouldEqual, fmt.Sprintf("/dimensions/%s", filterDims[1].Name))
-		So(overview.Dimensions[3].IsTruncated, ShouldBeTrue)
+		So(overview.Dimensions[3].Name, ShouldEqual, filterDims[0].Label)
+		So(overview.Dimensions[3].IsGeography, ShouldBeFalse)
+		So(overview.Dimensions[3].IsGeography, ShouldBeFalse)
+		So(overview.Dimensions[3].ID, ShouldEqual, filterDims[0].ID)
+		So(overview.Dimensions[3].URI, ShouldEqual, fmt.Sprintf("/dimensions/%s", filterDims[0].Name))
+		So(overview.Dimensions[3].IsTruncated, ShouldBeFalse)
+
+		So(overview.Dimensions[4].Name, ShouldEqual, filterDims[1].Label)
+		So(overview.Dimensions[4].IsGeography, ShouldBeFalse)
+		So(overview.Dimensions[4].IsGeography, ShouldBeFalse)
+		So(overview.Dimensions[4].ID, ShouldEqual, filterDims[1].ID)
+		So(overview.Dimensions[4].URI, ShouldEqual, fmt.Sprintf("/dimensions/%s", filterDims[1].Name))
+		So(overview.Dimensions[4].IsTruncated, ShouldBeTrue)
 
 		So(overview.EmergencyBanner, ShouldResemble, mappedEmergencyBanner())
 		So(overview.ServiceMessage, ShouldEqual, sm)
@@ -186,35 +186,35 @@ func TestOverview(t *testing.T) {
 	})
 
 	Convey("test truncation maps as expected", t, func() {
-		overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false, false)
-		So(overview.Dimensions[3].OptionsCount, ShouldEqual, filterDims[1].OptionsCount)
-		So(overview.Dimensions[3].Options, ShouldHaveLength, 9)
-		So(overview.Dimensions[3].Options[:3], ShouldResemble, []string{"Opt 1", "Opt 2", "Opt 3"})
-		So(overview.Dimensions[3].Options[3:6], ShouldResemble, []string{"Opt 9", "Opt 10", "Opt 11"})
-		So(overview.Dimensions[3].Options[6:], ShouldResemble, []string{"Opt 18", "Opt 19", "Opt 20"})
-		So(overview.Dimensions[3].IsTruncated, ShouldBeTrue)
-
-		So(overview.Dimensions[4].OptionsCount, ShouldEqual, filterDims[2].OptionsCount)
+		overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false)
+		So(overview.Dimensions[4].OptionsCount, ShouldEqual, filterDims[1].OptionsCount)
 		So(overview.Dimensions[4].Options, ShouldHaveLength, 9)
 		So(overview.Dimensions[4].Options[:3], ShouldResemble, []string{"Opt 1", "Opt 2", "Opt 3"})
-		So(overview.Dimensions[4].Options[3:6], ShouldResemble, []string{"Opt 5", "Opt 6", "Opt 7"})
-		So(overview.Dimensions[4].Options[6:], ShouldResemble, []string{"Opt 10", "Opt 11", "Opt 12"})
+		So(overview.Dimensions[4].Options[3:6], ShouldResemble, []string{"Opt 9", "Opt 10", "Opt 11"})
+		So(overview.Dimensions[4].Options[6:], ShouldResemble, []string{"Opt 18", "Opt 19", "Opt 20"})
 		So(overview.Dimensions[4].IsTruncated, ShouldBeTrue)
+
+		So(overview.Dimensions[5].OptionsCount, ShouldEqual, filterDims[2].OptionsCount)
+		So(overview.Dimensions[5].Options, ShouldHaveLength, 9)
+		So(overview.Dimensions[5].Options[:3], ShouldResemble, []string{"Opt 1", "Opt 2", "Opt 3"})
+		So(overview.Dimensions[5].Options[3:6], ShouldResemble, []string{"Opt 5", "Opt 6", "Opt 7"})
+		So(overview.Dimensions[5].Options[6:], ShouldResemble, []string{"Opt 10", "Opt 11", "Opt 12"})
+		So(overview.Dimensions[5].IsTruncated, ShouldBeTrue)
 	})
 
 	Convey("test truncation shows all when parameter given", t, func() {
 		m.req = httptest.NewRequest("", "/?showAll=Truncated+dim+2", nil)
-		overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false, false)
-		So(overview.Dimensions[4].OptionsCount, ShouldEqual, filterDims[2].OptionsCount)
-		So(overview.Dimensions[4].Options, ShouldHaveLength, 12)
-		So(overview.Dimensions[4].IsTruncated, ShouldBeFalse)
+		overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false)
+		So(overview.Dimensions[5].OptionsCount, ShouldEqual, filterDims[2].OptionsCount)
+		So(overview.Dimensions[5].Options, ShouldHaveLength, 12)
+		So(overview.Dimensions[5].IsTruncated, ShouldBeFalse)
 	})
 
 	Convey("test area type dimension options do not truncate and map to 'coverage' dimension", t, func() {
-		overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false, false)
-		So(overview.Dimensions[1].Options, ShouldHaveLength, 10)
-		So(overview.Dimensions[1].IsTruncated, ShouldBeFalse)
-		So(overview.Dimensions[1].IsCoverage, ShouldBeTrue)
+		overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false)
+		So(overview.Dimensions[2].Options, ShouldHaveLength, 10)
+		So(overview.Dimensions[2].IsTruncated, ShouldBeFalse)
+		So(overview.Dimensions[2].IsGeography, ShouldBeTrue)
 	})
 
 	Convey("test filter dims format labels using cleanDimensionLabel", t, func() {
@@ -228,21 +228,22 @@ func TestOverview(t *testing.T) {
 			},
 		}...)
 
-		overview := m.CreateFilterFlexOverview(filterJob, newFilterDims, dimDescriptions, sdc, false, false)
-		So(overview.Dimensions[5].Name, ShouldEqual, "Example")
+		overview := m.CreateFilterFlexOverview(filterJob, newFilterDims, dimDescriptions, sdc, false)
+		So(overview.Dimensions[6].Name, ShouldEqual, "Example")
 	})
 
-	Convey("given hasNoAreaOptions parameter", t, func() {
-		Convey("when parameter is true", func() {
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true, false)
-			Convey("then isDefaultCoverage is set to true", func() {
-				So(overview.Dimensions[1].IsDefaultCoverage, ShouldBeTrue)
+	Convey("Given area type selection", t, func() {
+		Convey("When area types are selected", func() {
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false)
+			Convey("Then area selection is displayed", func() {
+				So(overview.Dimensions[2].Options, ShouldResemble, filterDims[3].Options)
 			})
 		})
-		Convey("when parameter is false", func() {
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false, false)
-			Convey("then isDefaultCoverage is set to false", func() {
-				So(overview.Dimensions[1].IsDefaultCoverage, ShouldBeFalse)
+		Convey("When no area types are selected", func() {
+			filterDims[3].Options = []string{}
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false)
+			Convey("Then the default coverage is displayed", func() {
+				So(overview.Dimensions[2].Options[0], ShouldResemble, "England and Wales")
 			})
 		})
 	})
@@ -252,7 +253,7 @@ func TestOverview(t *testing.T) {
 			sdc.Blocked = 10
 			sdc.Passed = 15
 			sdc.Total = 25
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false, true)
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true)
 			Convey("Then the bool isMultivariate is true", func() {
 				So(overview.IsMultivariate, ShouldBeTrue)
 			})
@@ -276,7 +277,7 @@ func TestOverview(t *testing.T) {
 			sdc.Blocked = 0
 			sdc.Passed = 25
 			sdc.Total = 25
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false, true)
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true)
 			Convey("Then the bool isMultivariate is true", func() {
 				So(overview.IsMultivariate, ShouldBeTrue)
 			})
@@ -300,34 +301,34 @@ func TestOverview(t *testing.T) {
 
 	Convey("test IsChangeVisible parameter", t, func() {
 		Convey("when isMultivariate is false", func() {
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true, false)
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false)
 			Convey("then IsChangeCategories is false for all", func() {
-				So(overview.Dimensions[2].IsChangeCategories, ShouldBeFalse)
-				So(overview.Dimensions[3].IsChangeCategories, ShouldBeFalse)
-				So(overview.Dimensions[4].IsChangeCategories, ShouldBeFalse)
+				So(overview.Dimensions[3].HasChange, ShouldBeFalse)
+				So(overview.Dimensions[4].HasChange, ShouldBeFalse)
+				So(overview.Dimensions[5].HasChange, ShouldBeFalse)
 			})
 		})
 
 		Convey("when isMultivariate is true", func() {
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true, true)
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true)
 			Convey("then IsChangeCategories is false if categorisation is only one available", func() {
-				So(overview.Dimensions[2].IsChangeCategories, ShouldBeFalse)
-				So(overview.Dimensions[3].IsChangeCategories, ShouldBeTrue)
-				So(overview.Dimensions[4].IsChangeCategories, ShouldBeTrue)
+				So(overview.Dimensions[3].HasChange, ShouldBeFalse)
+				So(overview.Dimensions[4].HasChange, ShouldBeTrue)
+				So(overview.Dimensions[5].HasChange, ShouldBeTrue)
 			})
 		})
 	})
 
 	Convey("test EnableGetData boolean", t, func() {
 		Convey("when isMultivariate is false", func() {
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true, false)
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, false)
 			Convey("then EnableGetData should be true", func() {
 				So(overview.EnableGetData, ShouldBeTrue)
 			})
 		})
 
 		Convey("when isMultivariate is true and one or more dimensions are added", func() {
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true, true)
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true)
 			Convey("then EnableGetData should be true", func() {
 				So(overview.EnableGetData, ShouldBeTrue)
 			})
@@ -356,7 +357,7 @@ func TestOverview(t *testing.T) {
 					CategorisationCount: 2,
 				},
 			}
-			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true, true)
+			overview := m.CreateFilterFlexOverview(filterJob, filterDims, dimDescriptions, sdc, true)
 			Convey("then EnableGetData should be false", func() {
 				So(overview.EnableGetData, ShouldBeFalse)
 			})

--- a/mapper/overview_test.go
+++ b/mapper/overview_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/helpers"
@@ -128,7 +129,7 @@ func TestOverview(t *testing.T) {
 			},
 		},
 	}
-	sdc := population.GetBlockedAreaCountResult{
+	sdc := cantabular.GetBlockedAreaCountResult{
 		Passed:  100,
 		Blocked: 0,
 		Total:   100,

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -47,6 +47,12 @@ var cyLocale = []string{
 	"[SDCAllAreasAvailable]",
 	"one = \"1 area available (cy)\"",
 	"other = \"All areas available (cy)\"",
+	"[AreaTypeCoverageTitle]",
+	"one = \"Coverage (cy)\"",
+	"[AreaTypeDefaultCoverage]",
+	"one = \"England and Wales (cy)\"",
+	"[AreaTypeDescription]",
+	"one = \"Area type (cy)\"",
 }
 
 var enLocale = []string{
@@ -94,6 +100,12 @@ var enLocale = []string{
 	"[SDCAllAreasAvailable]",
 	"one = \"1 area available\"",
 	"other = \"All areas available\"",
+	"[AreaTypeCoverageTitle]",
+	"one = \"Coverage\"",
+	"[AreaTypeDefaultCoverage]",
+	"one = \"England and Wales\"",
+	"[AreaTypeDescription]",
+	"one = \"Area type\"",
 }
 
 // MockAssetFunction returns mocked toml []bytes

--- a/model/dimesion.go
+++ b/model/dimesion.go
@@ -4,17 +4,16 @@ import "github.com/ONSdigital/dp-api-clients-go/v2/filter"
 
 // Dimension represents the data for a single dimension
 type Dimension struct {
-	Options            []string `json:"options"`
-	IsTruncated        bool     `json:"is_truncated"`
-	TruncateLink       string   `json:"truncate_link"`
-	OptionsCount       int      `json:"options_count"`
-	Name               string   `json:"name"`
-	ID                 string   `json:"id"`
-	URI                string   `json:"uri"`
-	IsAreaType         bool     `json:"is_area_type"`
-	IsCoverage         bool     `json:"is_coverage"`
-	IsDefaultCoverage  bool     `json:"is_default_coverage"`
-	IsChangeCategories bool     `json:"is_change_categories"`
+	Options       []string `json:"options"`
+	IsTruncated   bool     `json:"is_truncated"`
+	TruncateLink  string   `json:"truncate_link"`
+	OptionsCount  int      `json:"options_count"`
+	Name          string   `json:"name"`
+	ID            string   `json:"id"`
+	URI           string   `json:"uri"`
+	IsGeography   bool     `json:"is_geography"`
+	HasCategories bool     `json:"has_categories"`
+	HasChange     bool     `json:"has_change"`
 }
 
 // FilterDimension represents a DTO for filter.Dimension with the additional OptionsCount field


### PR DESCRIPTION
### What

- Refactored the variables table to move logic away from the template
- Added api call to get population types; only single type is required but this endpoint has not been developed
***Partly*** resolves trello ticket [Tweak multivariate pages for build your own](https://trello.com/c/0OSSiNk4/6035-tweak-multivariate-pages-for-build-your-own)

### How to review

Sense check
Tests pass
Image review

<img width="710" alt="variables table" src="https://user-images.githubusercontent.com/19624419/221219135-ad51ac64-25a3-4b84-a07f-354437a57027.png">

### Who can review

Frontend go dev
