### PR TITLE
Override lowest geography

### DIFF
--- a/handlers/dimensions.go
+++ b/handlers/dimensions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
+	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/helpers"
 	"github.com/ONSdigital/dp-frontend-filter-flex-dataset/mapper"
 	"github.com/ONSdigital/dp-net/v2/handlers"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -148,9 +149,25 @@ func dimensionSelector(w http.ResponseWriter, req *http.Request, f *FilterFlex, 
 		return
 	}
 
+	lowestGeography := overrideLowestGeography(details.LowestGeography, currentFilter.PopulationType, helpers.IsBoolPtr(currentFilter.Custom))
+
 	m := mapper.NewMapper(req, basePage, eb, lang, serviceMsg, filterID)
-	selector := m.CreateAreaTypeSelector(areaTypes.AreaTypes, filterDimension, details.LowestGeography, releaseDate, dataset, hasOpts)
+	selector := m.CreateAreaTypeSelector(areaTypes.AreaTypes, filterDimension, lowestGeography, releaseDate, dataset, hasOpts)
 	f.Render.BuildPage(w, selector, "selector")
+}
+
+func overrideLowestGeography(defaultLowestGeography, populationType string, isCustom bool) string {
+	overrides := map[string]string{
+		"UR_CE": "msoa",
+	}
+	if isCustom {
+		lowestGeography, isOverridden := overrides[populationType]
+		if isOverridden {
+			return lowestGeography
+		}
+	}
+
+	return defaultLowestGeography
 }
 
 // isAreaType determines if the current dimension is an area type

--- a/handlers/dimensions_test.go
+++ b/handlers/dimensions_test.go
@@ -832,6 +832,20 @@ func TestDimensionsHandler(t *testing.T) {
 				})
 			})
 		})
+
+	})
+
+	Convey("Lowest geography override", t, func() {
+		Convey("Test the override function", func() {
+			hardcodedPopulation := "UR_CE"
+			hardcodedLG := "msoa"
+			defaultLG := "default"
+
+			So(overrideLowestGeography(defaultLG, hardcodedPopulation, true), ShouldEqual, hardcodedLG)
+			So(overrideLowestGeography(defaultLG, hardcodedPopulation, false), ShouldEqual, defaultLG)
+			So(overrideLowestGeography(defaultLG, "normal population", true), ShouldEqual, defaultLG)
+			So(overrideLowestGeography(defaultLG, "normal population", false), ShouldEqual, defaultLG)
+		})
 	})
 }
 


### PR DESCRIPTION
### What

Override lowest geography only in the instance that population type is UR_CE on the BYO journey which should be overridden by msoa

### How to review

Sense check
Tests pass

### Who can review

!me
